### PR TITLE
Fix balance sync and improve auth UX

### DIFF
--- a/frontend/src/components/AuthModal.tsx
+++ b/frontend/src/components/AuthModal.tsx
@@ -6,11 +6,12 @@ interface AuthModalProps {
   status: 'checking' | 'authenticated' | 'unauthenticated'
   onLogin: (email: string, password: string) => Promise<AuthResult>
   onRegister: (email: string, password: string, nickname: string) => Promise<AuthResult>
+  onClose?: () => void
 }
 
 type AuthMode = 'login' | 'register'
 
-export function AuthModal({ open, status, onLogin, onRegister }: AuthModalProps) {
+export function AuthModal({ open, status, onLogin, onRegister, onClose }: AuthModalProps) {
   const [mode, setMode] = useState<AuthMode>('login')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -22,6 +23,11 @@ export function AuthModal({ open, status, onLogin, onRegister }: AuthModalProps)
   const isLoading = status === 'checking' || submitting
 
   const title = useMemo(() => (mode === 'login' ? 'Вход в аккаунт' : 'Регистрация'), [mode])
+
+  const handleClose = () => {
+    if (isLoading) return
+    onClose?.()
+  }
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
@@ -52,6 +58,17 @@ export function AuthModal({ open, status, onLogin, onRegister }: AuthModalProps)
   return (
     <div className={overlayClass} aria-hidden={!open}>
       <div className="card auth-card">
+        {onClose && (
+          <button
+            type="button"
+            className="auth-close"
+            onClick={handleClose}
+            aria-label="Закрыть окно авторизации"
+            disabled={isLoading}
+          >
+            ×
+          </button>
+        )}
         <div className="auth-toggle" role="tablist">
           <button
             type="button"

--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -17,6 +17,7 @@ interface NicknameScreenProps {
   onStart: () => void
   startDisabled: boolean
   startDisabledHint?: string
+  startLabel?: string
 }
 
 export function NicknameScreen({
@@ -33,7 +34,8 @@ export function NicknameScreen({
   balance,
   onStart,
   startDisabled,
-  startDisabledHint
+  startDisabledHint,
+  startLabel
 }: NicknameScreenProps) {
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
@@ -104,7 +106,7 @@ export function NicknameScreen({
             </div>
           </div>
           <button id="startBtn" className="primary" type="submit" disabled={startDisabled} aria-disabled={startDisabled}>
-            Играть
+            {startLabel ?? 'Играть'}
           </button>
           {startDisabled && startDisabledHint && (
             <p className="start-hint">{startDisabledHint}</p>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -259,6 +259,25 @@
         .auth-card {
             width: min(420px, 92vw);
             max-width: 440px;
+            position: relative;
+        }
+
+        .auth-close {
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            border: none;
+            background: transparent;
+            color: rgba(226, 232, 240, 0.75);
+            font-size: 24px;
+            line-height: 1;
+            cursor: pointer;
+            padding: 4px;
+        }
+
+        .auth-close:disabled {
+            cursor: default;
+            opacity: 0.5;
         }
 
         .card h2 {


### PR DESCRIPTION
## Summary
- prevent multiple simultaneous sessions for one account by tracking active connections on the server
- clamp bet inputs, sync balances from auth updates, and gate the start button behind an explicit login action in the client
- add an auth modal close control with styling updates and expose a customizable CTA label on the nickname screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e5d5ce188331875ba019fd7fd209