### PR TITLE
Add Solana wallet integration and admin dashboard

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
+        "node-fetch": "^3.3.2",
         "pg": "^8.11.5",
         "sequelize": "^6.37.1",
         "sqlite3": "^5.1.7",
@@ -183,6 +184,26 @@
         "node-fetch": "^2.7.0",
         "rpc-websockets": "^9.0.2",
         "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/helpers": {
@@ -742,6 +763,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1075,6 +1105,29 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1097,6 +1150,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -2004,24 +2069,42 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp": {
@@ -3245,6 +3328,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^3.3.2",
     "pg": "^8.11.5",
     "sequelize": "^6.37.1",
     "sqlite3": "^5.1.7",

--- a/backend/src/models/GameWallet.js
+++ b/backend/src/models/GameWallet.js
@@ -1,0 +1,34 @@
+const { DataTypes, Model } = require('sequelize')
+const { sequelize } = require('../db/sequelize')
+
+class GameWallet extends Model {}
+
+GameWallet.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true
+    },
+    label: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'game'
+    },
+    publicKey: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    secretKey: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    }
+  },
+  {
+    sequelize,
+    modelName: 'GameWallet',
+    tableName: 'game_wallets'
+  }
+)
+
+module.exports = { GameWallet }

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -30,7 +30,16 @@ User.init(
     balance: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      defaultValue: 10
+      defaultValue: 0
+    },
+    walletPublicKey: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    walletSecretKey: {
+      type: DataTypes.TEXT,
+      allowNull: false
     }
   },
   {

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,38 @@
+const express = require('express')
+const walletService = require('../services/walletService')
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@tend.kz'
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'Pia753!!'
+
+const router = express.Router()
+
+router.use((req, res, next) => {
+  const header = req.headers.authorization || ''
+  if (!header.startsWith('Basic ')) {
+    res.setHeader('WWW-Authenticate', 'Basic realm="Admin Area"')
+    return res.status(401).json({ error: 'unauthorized' })
+  }
+  const encoded = header.slice(6)
+  let decoded = ''
+  try {
+    decoded = Buffer.from(encoded, 'base64').toString('utf8')
+  } catch (err) {
+    return res.status(401).json({ error: 'unauthorized' })
+  }
+  const [email, password] = decoded.split(':')
+  if (email !== ADMIN_EMAIL || password !== ADMIN_PASSWORD) {
+    return res.status(401).json({ error: 'unauthorized' })
+  }
+  next()
+})
+
+router.get('/overview', async (req, res) => {
+  try {
+    const data = await walletService.getAdminOverview()
+    res.json({ status: 'ok', data })
+  } catch (err) {
+    res.status(500).json({ error: 'admin_overview_failed' })
+  }
+})
+
+module.exports = router

--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -1,0 +1,64 @@
+const express = require('express')
+const { verifyToken, sanitizeUser } = require('../services/authService')
+const walletService = require('../services/walletService')
+const { User } = require('../models/User')
+
+const router = express.Router()
+
+router.use(async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization || ''
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+    if (!token) {
+      return res.status(401).json({ error: 'unauthorized' })
+    }
+    const payload = await verifyToken(token)
+    if (!payload) {
+      return res.status(401).json({ error: 'unauthorized' })
+    }
+    const user = await User.findByPk(payload.id)
+    if (!user) {
+      return res.status(401).json({ error: 'unauthorized' })
+    }
+    req.user = user
+    next()
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.get('/me', async (req, res) => {
+  try {
+    const profile = await walletService.getWalletProfile(req.user.id)
+    const sanitized = sanitizeUser(req.user)
+    res.json({ ...profile, user: sanitized })
+  } catch (err) {
+    res.status(500).json({ error: 'wallet_profile_failed' })
+  }
+})
+
+router.post('/airdrop', async (req, res) => {
+  try {
+    const amount = Number(req.body?.amountSol || 0)
+    const info = await walletService.requestUserAirdrop(req.user.id, amount > 0 ? amount : 1)
+    const profile = await walletService.getWalletProfile(req.user.id)
+    res.json({ status: 'ok', balance: profile, info })
+  } catch (err) {
+    if (err.message === 'invalid_amount') {
+      res.status(400).json({ error: 'invalid_amount' })
+    } else {
+      res.status(500).json({ error: 'airdrop_failed' })
+    }
+  }
+})
+
+router.post('/refresh', async (req, res) => {
+  try {
+    const profile = await walletService.getWalletProfile(req.user.id)
+    res.json({ status: 'ok', balance: profile })
+  } catch (err) {
+    res.status(500).json({ error: 'wallet_refresh_failed' })
+  }
+})
+
+module.exports = router

--- a/backend/src/services/solanaService.js
+++ b/backend/src/services/solanaService.js
@@ -1,0 +1,106 @@
+const bs58 = require('bs58')
+const {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+  clusterApiUrl
+} = require('@solana/web3.js')
+
+const fetchImpl = globalThis.fetch
+  ? globalThis.fetch.bind(globalThis)
+  : (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args))
+
+const SOLANA_CLUSTER = process.env.SOLANA_CLUSTER || 'devnet'
+const connection = new Connection(clusterApiUrl(SOLANA_CLUSTER), 'confirmed')
+
+function createKeypair() {
+  const keypair = Keypair.generate()
+  return {
+    publicKey: keypair.publicKey.toBase58(),
+    secretKey: bs58.encode(keypair.secretKey)
+  }
+}
+
+function decodeSecret(secret) {
+  if (!secret) throw new Error('missing_secret')
+  return Keypair.fromSecretKey(bs58.decode(secret))
+}
+
+async function getBalance(publicKey) {
+  if (!publicKey) return 0
+  try {
+    const key = new PublicKey(publicKey)
+    return await connection.getBalance(key)
+  } catch (err) {
+    console.error('Failed to fetch balance', err)
+    throw err
+  }
+}
+
+async function requestAirdrop(publicKey, solAmount) {
+  if (!publicKey) throw new Error('missing_public_key')
+  const key = new PublicKey(publicKey)
+  const lamports = Math.floor(Number(solAmount) * LAMPORTS_PER_SOL)
+  if (!Number.isFinite(lamports) || lamports <= 0) {
+    throw new Error('invalid_airdrop_amount')
+  }
+  const signature = await connection.requestAirdrop(key, lamports)
+  await connection.confirmTransaction(signature, 'confirmed')
+  return signature
+}
+
+async function transferLamports(secretKey, toPublicKey, lamports) {
+  if (!secretKey) throw new Error('missing_secret_key')
+  if (!toPublicKey) throw new Error('missing_destination')
+  const normalizedLamports = Math.floor(Number(lamports) || 0)
+  if (!Number.isFinite(normalizedLamports) || normalizedLamports <= 0) {
+    throw new Error('invalid_lamports')
+  }
+  const from = decodeSecret(secretKey)
+  const to = new PublicKey(toPublicKey)
+  const tx = new Transaction().add(SystemProgram.transfer({
+    fromPubkey: from.publicKey,
+    toPubkey: to,
+    lamports: normalizedLamports
+  }))
+  const signature = await sendAndConfirmTransaction(connection, tx, [from])
+  return signature
+}
+
+let cachedPrice = null
+let cachedAt = 0
+const PRICE_TTL_MS = 60_000
+
+async function fetchSolPriceUsd() {
+  const now = Date.now()
+  if (cachedPrice && now - cachedAt < PRICE_TTL_MS) {
+    return cachedPrice
+  }
+  try {
+    const res = await fetchImpl('https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd')
+    if (!res.ok) throw new Error('price_request_failed')
+    const data = await res.json()
+    const price = Number(data?.solana?.usd)
+    if (!Number.isFinite(price) || price <= 0) throw new Error('invalid_price')
+    cachedPrice = price
+    cachedAt = now
+    return price
+  } catch (err) {
+    console.error('Failed to fetch SOL price', err)
+    throw err
+  }
+}
+
+module.exports = {
+  connection,
+  createKeypair,
+  getBalance,
+  requestAirdrop,
+  transferLamports,
+  fetchSolPriceUsd,
+  LAMPORTS_PER_SOL
+}

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -1,0 +1,177 @@
+const { Op } = require('sequelize')
+const { GameWallet } = require('../models/GameWallet')
+const { User } = require('../models/User')
+const solana = require('./solanaService')
+
+const LAMPORTS_PER_UNIT = Number(process.env.LAMPORTS_PER_UNIT || 1_000_000)
+const INITIAL_AIRDROP_SOL = Number(process.env.INITIAL_AIRDROP_SOL || 1)
+
+function unitsToLamports(units) {
+  return Math.max(0, Math.floor(Number(units) * LAMPORTS_PER_UNIT))
+}
+
+function lamportsToUnits(lamports) {
+  return Math.max(0, Math.floor(Number(lamports) / LAMPORTS_PER_UNIT))
+}
+
+async function ensureGameWallet() {
+  let wallet = await GameWallet.findByPk(1)
+  if (wallet) return wallet
+  const kp = solana.createKeypair()
+  wallet = await GameWallet.create({
+    id: 1,
+    label: 'game',
+    publicKey: kp.publicKey,
+    secretKey: kp.secretKey
+  })
+  return wallet
+}
+
+async function getGameWallet() {
+  const wallet = await ensureGameWallet()
+  return wallet
+}
+
+async function createUserWallet() {
+  const kp = solana.createKeypair()
+  return kp
+}
+
+async function refreshUserBalance(user) {
+  if (!user) return { units: 0, lamports: 0 }
+  if (!user.walletPublicKey) {
+    return { units: user.balance || 0, lamports: 0 }
+  }
+  const lamports = await solana.getBalance(user.walletPublicKey)
+  const units = lamportsToUnits(lamports)
+  if (user.balance !== units) {
+    user.balance = units
+    await user.save({ fields: ['balance'] })
+  }
+  return { units, lamports }
+}
+
+async function refreshUserBalanceById(userId) {
+  if (!userId) return { units: 0, lamports: 0 }
+  const user = await User.findByPk(userId)
+  if (!user) return { units: 0, lamports: 0 }
+  return refreshUserBalance(user)
+}
+
+async function requestInitialAirdrop(user) {
+  if (!user || INITIAL_AIRDROP_SOL <= 0) return null
+  try {
+    await solana.requestAirdrop(user.walletPublicKey, INITIAL_AIRDROP_SOL)
+    return refreshUserBalance(user)
+  } catch (err) {
+    console.error('Failed to perform initial airdrop', err)
+    return null
+  }
+}
+
+async function transferUserToGame(userId, amountUnits) {
+  if (!userId) throw new Error('missing_user_id')
+  const user = await User.findByPk(userId)
+  if (!user) throw new Error('user_not_found')
+  const wallet = await getGameWallet()
+  const lamports = unitsToLamports(amountUnits)
+  if (lamports <= 0) throw new Error('invalid_amount')
+  const current = await solana.getBalance(user.walletPublicKey)
+  if (current < lamports) {
+    throw new Error('insufficient_funds')
+  }
+  await solana.transferLamports(user.walletSecretKey, wallet.publicKey, lamports)
+  const { units } = await refreshUserBalance(user)
+  return { units }
+}
+
+async function transferGameToUser(userId, amountUnits) {
+  if (!userId) throw new Error('missing_user_id')
+  const user = await User.findByPk(userId)
+  if (!user) throw new Error('user_not_found')
+  const wallet = await getGameWallet()
+  const lamports = unitsToLamports(amountUnits)
+  if (lamports <= 0) throw new Error('invalid_amount')
+  await solana.transferLamports(wallet.secretKey, user.walletPublicKey, lamports)
+  const { units } = await refreshUserBalance(user)
+  return { units }
+}
+
+async function getWalletProfile(userId) {
+  const user = await User.findByPk(userId)
+  if (!user) return null
+  const { lamports, units } = await refreshUserBalance(user)
+  const priceUsd = await solana.fetchSolPriceUsd().catch(() => null)
+  const sol = lamports / solana.LAMPORTS_PER_SOL
+  const usd = priceUsd ? sol * priceUsd : null
+  return {
+    walletAddress: user.walletPublicKey,
+    lamports,
+    sol,
+    usd,
+    usdRate: priceUsd,
+    units,
+    inGameBalance: user.balance
+  }
+}
+
+async function requestUserAirdrop(userId, solAmount) {
+  const user = await User.findByPk(userId)
+  if (!user) throw new Error('user_not_found')
+  const normalized = Math.min(Math.max(Number(solAmount) || 0, 0.1), 5)
+  if (normalized <= 0) throw new Error('invalid_amount')
+  await solana.requestAirdrop(user.walletPublicKey, normalized)
+  return refreshUserBalance(user)
+}
+
+async function getAdminOverview() {
+  const [wallet, users] = await Promise.all([
+    getGameWallet(),
+    User.findAll({
+      order: [['id', 'ASC']],
+      where: {
+        walletPublicKey: { [Op.ne]: null }
+      }
+    })
+  ])
+  const balances = await Promise.all(
+    users.map(async (user) => {
+      const lamports = await solana.getBalance(user.walletPublicKey).catch(() => 0)
+      return {
+        id: user.id,
+        email: user.email,
+        nickname: user.nickname,
+        walletAddress: user.walletPublicKey,
+        walletLamports: lamports,
+        walletSol: lamports / solana.LAMPORTS_PER_SOL,
+        inGameBalance: user.balance
+      }
+    })
+  )
+  const gameLamports = await solana.getBalance(wallet.publicKey).catch(() => 0)
+  return {
+    users: balances,
+    gameWallet: {
+      walletAddress: wallet.publicKey,
+      walletLamports: gameLamports,
+      walletSol: gameLamports / solana.LAMPORTS_PER_SOL
+    }
+  }
+}
+
+module.exports = {
+  LAMPORTS_PER_UNIT,
+  unitsToLamports,
+  lamportsToUnits,
+  ensureGameWallet,
+  getGameWallet,
+  createUserWallet,
+  refreshUserBalance,
+  refreshUserBalanceById,
+  requestInitialAirdrop,
+  transferUserToGame,
+  transferGameToUser,
+  getWalletProfile,
+  requestUserAirdrop,
+  getAdminOverview
+}

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,0 +1,189 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+
+interface AdminUser {
+  id: number
+  email: string
+  nickname: string
+  walletAddress: string
+  walletLamports: number
+  walletSol: number
+  inGameBalance: number
+}
+
+interface AdminOverview {
+  users: AdminUser[]
+  gameWallet: {
+    walletAddress: string
+    walletLamports: number
+    walletSol: number
+  }
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+const STORAGE_KEY = 'admin_basic_token'
+
+export function AdminDashboard() {
+  const [email, setEmail] = useState('admin@tend.kz')
+  const [password, setPassword] = useState('')
+  const [token, setToken] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
+    return window.localStorage.getItem(STORAGE_KEY)
+  })
+  const [overview, setOverview] = useState<AdminOverview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchOverview = useCallback(
+    async (basicToken: string) => {
+      if (!basicToken) return
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/admin/overview`, {
+          headers: {
+            Authorization: `Basic ${basicToken}`
+          }
+        })
+        if (!res.ok) {
+          throw new Error('unauthorized')
+        }
+        const data = await res.json()
+        setOverview(data.data)
+        return data.data as AdminOverview
+      } catch (err) {
+        const message = (err as Error).message || 'request_failed'
+        setError(message)
+        setOverview(null)
+        if (message === 'unauthorized') {
+          if (typeof window !== 'undefined') {
+            window.localStorage.removeItem(STORAGE_KEY)
+          }
+          setToken(null)
+        }
+        return null
+      } finally {
+        setLoading(false)
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (token) {
+      fetchOverview(token)
+    }
+  }, [fetchOverview, token])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault()
+      const normalizedEmail = email.trim()
+      const basic = btoa(`${normalizedEmail}:${password}`)
+      window.localStorage.setItem(STORAGE_KEY, basic)
+      setToken(basic)
+      await fetchOverview(basic)
+    },
+    [email, password, fetchOverview]
+  )
+
+  const handleLogout = useCallback(() => {
+    window.localStorage.removeItem(STORAGE_KEY)
+    setToken(null)
+    setOverview(null)
+    setPassword('')
+  }, [])
+
+  const totalSol = useMemo(() => {
+    if (!overview) return 0
+    return overview.users.reduce((sum, user) => sum + (user.walletSol || 0), overview.gameWallet.walletSol || 0)
+  }, [overview])
+
+  if (!token || !overview) {
+    return (
+      <div className="admin-wrapper">
+        <div className="admin-card">
+          <h1>Admin Portal</h1>
+          <form onSubmit={handleSubmit} className="admin-form">
+            <label>
+              Email
+              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            </label>
+            <label>
+              Пароль
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </label>
+            <button type="submit" disabled={loading}>
+              {loading ? 'Проверка...' : 'Войти'}
+            </button>
+            {error && <div className="admin-error">Ошибка: {error}</div>}
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="admin-wrapper">
+      <div className="admin-card">
+        <div className="admin-header">
+          <div>
+            <h1>Сводка кошельков</h1>
+            <p className="admin-subtitle">Обновлено автоматически при входе</p>
+          </div>
+          <div className="admin-actions">
+            <button type="button" onClick={() => fetchOverview(token)} disabled={loading}>
+              {loading ? 'Обновление...' : 'Обновить'}
+            </button>
+            <button type="button" className="admin-secondary" onClick={handleLogout}>
+              Выйти
+            </button>
+          </div>
+        </div>
+        <div className="admin-summary">
+          <div>
+            <span className="summary-label">Игровой кошелек</span>
+            <span className="summary-value">{overview.gameWallet.walletSol.toFixed(3)} SOL</span>
+            <span className="summary-address">{overview.gameWallet.walletAddress}</span>
+          </div>
+          <div>
+            <span className="summary-label">Всего SOL</span>
+            <span className="summary-value">{totalSol.toFixed(3)} SOL</span>
+          </div>
+        </div>
+        <div className="admin-table">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Email</th>
+                <th>Ник</th>
+                <th>Кошелек</th>
+                <th>Баланс (SOL)</th>
+                <th>Lamports</th>
+                <th>Игровой баланс</th>
+              </tr>
+            </thead>
+            <tbody>
+              {overview.users.map((user) => (
+                <tr key={user.id}>
+                  <td>{user.id}</td>
+                  <td>{user.email}</td>
+                  <td>{user.nickname}</td>
+                  <td className="mono">{user.walletAddress}</td>
+                  <td>{user.walletSol.toFixed(3)}</td>
+                  <td>{user.walletLamports.toLocaleString('en-US')}</td>
+                  <td>{user.inGameBalance}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ScorePanel.tsx
+++ b/frontend/src/components/ScorePanel.tsx
@@ -5,9 +5,30 @@ interface ScorePanelProps {
   score: number
   scoreMeta: string
   account: AccountState
+  walletAddress?: string | null
+  walletSol?: number
+  walletUsd?: number | null
+  usdRate?: number | null
+  walletLoading?: boolean
+  onRefreshWallet?: () => void
+  onTopUp?: () => void
 }
 
-export function ScorePanel({ score, scoreMeta, account }: ScorePanelProps) {
+export function ScorePanel({
+  score,
+  scoreMeta,
+  account,
+  walletAddress,
+  walletSol,
+  walletUsd,
+  usdRate,
+  walletLoading,
+  onRefreshWallet,
+  onTopUp
+}: ScorePanelProps) {
+  const formattedSol = typeof walletSol === 'number' ? walletSol.toFixed(3) : '0.000'
+  const formattedUsd = typeof walletUsd === 'number' ? walletUsd.toFixed(2) : '—'
+  const showWallet = Boolean(walletAddress)
   return (
     <div id="scorePanel" className="panel">
       <div className="label">Длина</div>
@@ -27,6 +48,43 @@ export function ScorePanel({ score, scoreMeta, account }: ScorePanelProps) {
           </span>
         </div>
       </div>
+      {showWallet && (
+        <div className="wallet-section">
+          <div className="wallet-row">
+            <span className="wallet-label">SOL</span>
+            <span className="wallet-value">{formattedSol}</span>
+          </div>
+          <div className="wallet-row">
+            <span className="wallet-label">USD</span>
+            <span className="wallet-value">
+              {formattedUsd}
+              {usdRate ? <span className="wallet-rate">@{usdRate.toFixed(2)}</span> : null}
+            </span>
+          </div>
+          <div className="wallet-address" title={walletAddress ?? ''}>
+            <span className="wallet-label">Кошелек</span>
+            <span className="wallet-hash">{walletAddress}</span>
+          </div>
+          <div className="wallet-actions">
+            <button
+              type="button"
+              className="wallet-button"
+              onClick={onTopUp}
+              disabled={walletLoading}
+            >
+              {walletLoading ? 'Обработка...' : 'Пополнить'}
+            </button>
+            <button
+              type="button"
+              className="wallet-button secondary"
+              onClick={onRefreshWallet}
+              disabled={walletLoading}
+            >
+              {walletLoading ? 'Обновление...' : 'Обновить'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -5,6 +5,7 @@ export interface AuthUser {
   email: string
   nickname: string
   balance: number
+  walletAddress: string | null
 }
 
 type AuthStatus = 'checking' | 'authenticated' | 'unauthenticated'

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -148,6 +148,10 @@ interface GameUIState {
   betValue: string
   retryBetValue: string
   touchControlsEnabled: boolean
+  transfer: {
+    pending: boolean
+    message: string
+  }
 }
 
 interface InternalState {
@@ -223,7 +227,11 @@ const initialUI: GameUIState = {
   selectedSkin: 'default',
   betValue: '10',
   retryBetValue: '',
-  touchControlsEnabled: false
+  touchControlsEnabled: false,
+  transfer: {
+    pending: false,
+    message: ''
+  }
 }
 
 export class GameController {
@@ -307,6 +315,14 @@ export class GameController {
     this.notify()
   }
 
+  setTransferState(pending: boolean, message?: string) {
+    this.state.ui.transfer = {
+      pending,
+      message: message ?? (pending ? 'Перевод средств…' : '')
+    }
+    this.notify()
+  }
+
   applyBalanceUpdate(payload: Partial<AccountState> & { cashedOut?: boolean }) {
     const next = { ...this.state.account }
     if (typeof payload.balance === 'number') next.balance = Math.max(0, Math.floor(payload.balance))
@@ -323,6 +339,9 @@ export class GameController {
       }
     }
     this.state.account = next
+    if (this.state.ui.transfer.pending) {
+      this.state.ui.transfer = { pending: false, message: '' }
+    }
     this.refreshCashoutState()
     this.notify()
   }
@@ -1022,6 +1041,7 @@ export function useGame() {
     boost: ui.boost,
     deathScreen: ui.death,
     cashoutScreen: ui.cashoutScreen,
+    transfer: ui.transfer,
     nicknameScreenVisible: ui.nicknameVisible,
     nickname: ui.nickname,
     nicknameLocked: ui.nicknameLocked,

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export interface WalletProfile {
+  walletAddress: string
+  lamports: number
+  sol: number
+  usd: number | null
+  usdRate: number | null
+  units: number
+  inGameBalance: number
+}
+
+interface UseWalletOptions {
+  token?: string | null
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+
+export function useWallet({ token }: UseWalletOptions) {
+  const [profile, setProfile] = useState<WalletProfile | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchProfile = useCallback(async () => {
+    if (!token) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/wallet/me`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      })
+      if (!res.ok) {
+        throw new Error('wallet_profile_failed')
+      }
+      const data = await res.json()
+      setProfile({
+        walletAddress: data.walletAddress,
+        lamports: data.lamports,
+        sol: data.sol,
+        usd: data.usd ?? null,
+        usdRate: data.usdRate ?? null,
+        units: data.units,
+        inGameBalance: data.inGameBalance
+      })
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [token])
+
+  useEffect(() => {
+    if (!token) {
+      setProfile(null)
+      return
+    }
+    fetchProfile()
+  }, [fetchProfile, token])
+
+  const refresh = useCallback(async () => {
+    if (!token) return null
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/wallet/refresh`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      })
+      if (!res.ok) {
+        throw new Error('wallet_refresh_failed')
+      }
+      const data = await res.json()
+      const balance = data.balance ?? {}
+      const next: WalletProfile = {
+        walletAddress: balance.walletAddress ?? profile?.walletAddress ?? '',
+        lamports: balance.lamports ?? profile?.lamports ?? 0,
+        sol: balance.sol ?? profile?.sol ?? 0,
+        usd: balance.usd ?? profile?.usd ?? null,
+        usdRate: balance.usdRate ?? profile?.usdRate ?? null,
+        units: balance.units ?? profile?.units ?? 0,
+        inGameBalance: balance.inGameBalance ?? profile?.inGameBalance ?? 0
+      }
+      setProfile(next)
+      return next
+    } catch (err) {
+      setError((err as Error).message)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [profile, token])
+
+  const requestAirdrop = useCallback(
+    async (amountSol: number) => {
+      if (!token) return null
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/wallet/airdrop`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify({ amountSol })
+        })
+        if (!res.ok) {
+          throw new Error('airdrop_failed')
+        }
+        const data = await res.json()
+        const balance = data.balance ?? {}
+        const next: WalletProfile = {
+          walletAddress: balance.walletAddress ?? profile?.walletAddress ?? '',
+          lamports: balance.lamports ?? profile?.lamports ?? 0,
+          sol: balance.sol ?? profile?.sol ?? 0,
+          usd: balance.usd ?? profile?.usd ?? null,
+          usdRate: balance.usdRate ?? profile?.usdRate ?? null,
+          units: balance.units ?? profile?.units ?? 0,
+          inGameBalance: balance.inGameBalance ?? profile?.inGameBalance ?? 0
+        }
+        setProfile(next)
+        return next
+      } catch (err) {
+        setError((err as Error).message)
+        return null
+      } finally {
+        setLoading(false)
+      }
+    },
+    [profile, token]
+  )
+
+  return {
+    profile,
+    loading,
+    error,
+    refresh,
+    requestAirdrop,
+    fetchProfile
+  }
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -100,6 +100,89 @@
             color: #f8fafc;
         }
 
+        #scorePanel .wallet-section {
+            margin-top: 12px;
+            padding-top: 10px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        #scorePanel .wallet-row {
+            display: flex;
+            justify-content: space-between;
+            font-size: clamp(12px, 2.6vw, 14px);
+            font-weight: 600;
+            color: #e0f2fe;
+        }
+
+        #scorePanel .wallet-label {
+            color: rgba(148, 163, 184, 0.8);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        #scorePanel .wallet-value {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        #scorePanel .wallet-rate {
+            font-size: 11px;
+            color: rgba(148, 163, 184, 0.7);
+        }
+
+        #scorePanel .wallet-address {
+            font-size: clamp(11px, 2.2vw, 13px);
+            color: rgba(226, 232, 240, 0.9);
+            word-break: break-all;
+            line-height: 1.4;
+        }
+
+        #scorePanel .wallet-hash {
+            display: block;
+            margin-top: 4px;
+            font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
+        }
+
+        #scorePanel .wallet-actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        #scorePanel .wallet-button {
+            flex: 1;
+            padding: 6px 10px;
+            border-radius: 10px;
+            border: none;
+            background: linear-gradient(135deg, #38bdf8, #2563eb);
+            color: #ffffff;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.12s ease;
+        }
+
+        #scorePanel .wallet-button.secondary {
+            background: rgba(148, 163, 184, 0.2);
+            color: #e2e8f0;
+        }
+
+        #scorePanel .wallet-button:disabled {
+            opacity: 0.6;
+            cursor: default;
+            box-shadow: none;
+        }
+
+        #scorePanel .wallet-button:not(:disabled):hover {
+            transform: translateY(-1px);
+            box-shadow: 0 8px 16px rgba(56, 189, 248, 0.35);
+        }
+
         #cashoutControl {
             position: fixed;
             left: 50%;
@@ -138,6 +221,212 @@
             cursor: default;
             opacity: 0.45;
             box-shadow: none;
+        }
+
+        .transfer-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.75);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 20;
+            backdrop-filter: blur(4px);
+        }
+
+        .transfer-modal {
+            background: rgba(15, 23, 42, 0.92);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 16px;
+            padding: 24px 32px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 16px;
+            min-width: min(90vw, 320px);
+            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+        }
+
+        .transfer-spinner {
+            width: 48px;
+            height: 48px;
+            border-radius: 999px;
+            border: 4px solid rgba(56, 189, 248, 0.25);
+            border-top-color: #38bdf8;
+            animation: spin 1s linear infinite;
+        }
+
+        .transfer-text {
+            font-size: 16px;
+            font-weight: 600;
+            color: #e2e8f0;
+            text-align: center;
+        }
+
+        @keyframes spin {
+            0% {
+                transform: rotate(0deg);
+            }
+            100% {
+                transform: rotate(360deg);
+            }
+        }
+
+        .admin-wrapper {
+            min-height: 100vh;
+            background: radial-gradient(circle at top, rgba(15, 23, 42, 0.9), #020617);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 32px;
+        }
+
+        .admin-card {
+            width: min(960px, 100%);
+            background: rgba(15, 23, 42, 0.88);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 24px;
+            padding: 32px;
+            color: #e2e8f0;
+            box-shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .admin-form {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .admin-form label {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 14px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: rgba(148, 163, 184, 0.9);
+        }
+
+        .admin-form input {
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            background: rgba(15, 23, 42, 0.6);
+            color: #f8fafc;
+        }
+
+        .admin-form button {
+            padding: 12px;
+            border-radius: 12px;
+            border: none;
+            background: linear-gradient(135deg, #38bdf8, #2563eb);
+            color: #fff;
+            font-size: 14px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .admin-error {
+            padding: 8px 12px;
+            border-radius: 10px;
+            background: rgba(248, 113, 113, 0.18);
+            color: #fecaca;
+            font-size: 13px;
+        }
+
+        .admin-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .admin-actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        .admin-actions button {
+            padding: 10px 14px;
+            border-radius: 10px;
+            border: none;
+            font-weight: 600;
+            cursor: pointer;
+            background: rgba(56, 189, 248, 0.2);
+            color: #bae6fd;
+        }
+
+        .admin-actions .admin-secondary {
+            background: rgba(248, 113, 113, 0.2);
+            color: #fecaca;
+        }
+
+        .admin-summary {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            border-radius: 18px;
+            padding: 16px 20px;
+        }
+
+        .summary-label {
+            display: block;
+            font-size: 12px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(148, 163, 184, 0.7);
+            margin-bottom: 6px;
+        }
+
+        .summary-value {
+            font-size: 20px;
+            font-weight: 700;
+            color: #f1f5f9;
+        }
+
+        .summary-address {
+            display: block;
+            margin-top: 4px;
+            font-size: 13px;
+            color: rgba(148, 163, 184, 0.85);
+            word-break: break-all;
+        }
+
+        .admin-table {
+            overflow-x: auto;
+        }
+
+        .admin-table table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 13px;
+        }
+
+        .admin-table th,
+        .admin-table td {
+            padding: 10px 12px;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+            text-align: left;
+        }
+
+        .admin-table th {
+            text-transform: uppercase;
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            color: rgba(148, 163, 184, 0.7);
+        }
+
+        .admin-table tbody tr:hover {
+            background: rgba(30, 41, 59, 0.45);
+        }
+
+        .admin-table .mono {
+            font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
         }
 
         .cashout-button.holding {


### PR DESCRIPTION
## Summary
- integrate Solana wallet creation, escrow transfers, and centralized game wallet management during registration, betting, and cashout flows
- expose authenticated wallet APIs alongside a basic-auth admin overview endpoint for monitoring user and game balances
- enhance the client with wallet balance controls, transfer loader feedback, and an admin dashboard view with refreshed styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d935724e248331b1ecae1a9105cf74