### PR TITLE
Move wallet controls to nickname overlay

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -234,18 +234,7 @@ function GameView() {
         onClose={() => setAuthModalOpen(false)}
       />
       <canvas id="canvas" ref={canvasRef} />
-      <ScorePanel
-        score={game.score}
-        scoreMeta={game.scoreMeta}
-        account={game.account}
-        walletAddress={wallet.profile?.walletAddress || auth.user?.walletAddress || null}
-        walletSol={wallet.profile?.sol}
-        walletUsd={wallet.profile?.usd ?? null}
-        usdRate={wallet.profile?.usdRate ?? null}
-        walletLoading={wallet.loading}
-        onRefreshWallet={handleWalletRefresh}
-        onTopUp={handleWalletTopUp}
-      />
+      <ScorePanel score={game.score} scoreMeta={game.scoreMeta} />
       <Leaderboard entries={game.leaderboard} meName={game.controller.state.meName} />
       <Minimap ref={minimapRef} />
       <TouchControls
@@ -268,10 +257,18 @@ function GameView() {
         onBetChange={handleBetChange}
         onBetBlur={handleBetBlur}
         balance={game.account.balance}
+        currentBet={game.account.currentBet}
         onStart={handlePrimaryAction}
         startDisabled={startDisabled}
         startLabel={startLabel}
         startDisabledHint={startHint}
+        walletAddress={wallet.profile?.walletAddress || auth.user?.walletAddress || null}
+        walletSol={wallet.profile?.sol}
+        walletUsd={wallet.profile?.usd ?? null}
+        usdRate={wallet.profile?.usdRate ?? null}
+        walletLoading={wallet.loading}
+        onRefreshWallet={handleWalletRefresh}
+        onTopUp={handleWalletTopUp}
       />
       <DeathScreen
         state={game.deathScreen}

--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -14,10 +14,18 @@ interface NicknameScreenProps {
   onBetChange: (value: string) => void
   onBetBlur: () => void
   balance: number
+  currentBet: number
   onStart: () => void
   startDisabled: boolean
   startDisabledHint?: string
   startLabel?: string
+  walletAddress?: string | null
+  walletSol?: number
+  walletUsd?: number | null
+  usdRate?: number | null
+  walletLoading?: boolean
+  onRefreshWallet?: () => void
+  onTopUp?: () => void
 }
 
 export function NicknameScreen({
@@ -32,16 +40,28 @@ export function NicknameScreen({
   onBetChange,
   onBetBlur,
   balance,
+  currentBet,
   onStart,
   startDisabled,
   startDisabledHint,
-  startLabel
+  startLabel,
+  walletAddress,
+  walletSol,
+  walletUsd,
+  usdRate,
+  walletLoading,
+  onRefreshWallet,
+  onTopUp
 }: NicknameScreenProps) {
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     if (startDisabled) return
     onStart()
   }
+
+  const formattedSol = typeof walletSol === 'number' ? walletSol.toFixed(3) : '0.000'
+  const formattedUsd = typeof walletUsd === 'number' ? walletUsd.toFixed(2) : '—'
+  const showWallet = Boolean(walletAddress)
 
   return (
     <div id="nicknameScreen" className={visible ? 'overlay' : 'overlay hidden'}>
@@ -90,6 +110,57 @@ export function NicknameScreen({
               ))}
             </div>
           </div>
+          <div className="account">
+            <div className="account-row">
+              <span className="account-label">Баланс</span>
+              <span className="account-value" id="balanceValue">
+                {formatNumber(balance)}
+              </span>
+            </div>
+            <div className="account-row">
+              <span className="account-label">Текущая ставка</span>
+              <span className="account-value">
+                {formatNumber(currentBet)}
+              </span>
+            </div>
+          </div>
+          {showWallet && (
+            <div className="wallet-section">
+              <div className="wallet-row">
+                <span className="wallet-label">SOL</span>
+                <span className="wallet-value">{formattedSol}</span>
+              </div>
+              <div className="wallet-row">
+                <span className="wallet-label">USD</span>
+                <span className="wallet-value">
+                  {formattedUsd}
+                  {usdRate ? <span className="wallet-rate">@{usdRate.toFixed(2)}</span> : null}
+                </span>
+              </div>
+              <div className="wallet-address" title={walletAddress ?? ''}>
+                <span className="wallet-label">Кошелек</span>
+                <span className="wallet-hash">{walletAddress}</span>
+              </div>
+              <div className="wallet-actions">
+                <button
+                  type="button"
+                  className="wallet-button"
+                  onClick={onTopUp}
+                  disabled={walletLoading}
+                >
+                  {walletLoading ? 'Обработка...' : 'Пополнить'}
+                </button>
+                <button
+                  type="button"
+                  className="wallet-button secondary"
+                  onClick={onRefreshWallet}
+                  disabled={walletLoading}
+                >
+                  {walletLoading ? 'Обновление...' : 'Обновить'}
+                </button>
+              </div>
+            </div>
+          )}
           <div className="bet-control">
             <label htmlFor="betInput">Ставка перед стартом</label>
             <input

--- a/frontend/src/components/ScorePanel.tsx
+++ b/frontend/src/components/ScorePanel.tsx
@@ -1,90 +1,16 @@
 import { formatNumber } from '../utils/helpers'
-import type { AccountState } from '../hooks/useGame'
 
 interface ScorePanelProps {
   score: number
   scoreMeta: string
-  account: AccountState
-  walletAddress?: string | null
-  walletSol?: number
-  walletUsd?: number | null
-  usdRate?: number | null
-  walletLoading?: boolean
-  onRefreshWallet?: () => void
-  onTopUp?: () => void
 }
 
-export function ScorePanel({
-  score,
-  scoreMeta,
-  account,
-  walletAddress,
-  walletSol,
-  walletUsd,
-  usdRate,
-  walletLoading,
-  onRefreshWallet,
-  onTopUp
-}: ScorePanelProps) {
-  const formattedSol = typeof walletSol === 'number' ? walletSol.toFixed(3) : '0.000'
-  const formattedUsd = typeof walletUsd === 'number' ? walletUsd.toFixed(2) : '—'
-  const showWallet = Boolean(walletAddress)
+export function ScorePanel({ score, scoreMeta }: ScorePanelProps) {
   return (
     <div id="scorePanel" className="panel">
       <div className="label">Длина</div>
       <div id="scoreValue">{formatNumber(score)}</div>
       <div id="scoreMeta">{scoreMeta}</div>
-      <div className="account">
-        <div className="account-row">
-          <span className="account-label">Баланс</span>
-          <span className="account-value" id="balanceValue">
-            {formatNumber(account.balance)}
-          </span>
-        </div>
-        <div className="account-row">
-          <span className="account-label">Ставка</span>
-          <span className="account-value" id="betValue">
-            {formatNumber(account.currentBet)}
-          </span>
-        </div>
-      </div>
-      {showWallet && (
-        <div className="wallet-section">
-          <div className="wallet-row">
-            <span className="wallet-label">SOL</span>
-            <span className="wallet-value">{formattedSol}</span>
-          </div>
-          <div className="wallet-row">
-            <span className="wallet-label">USD</span>
-            <span className="wallet-value">
-              {formattedUsd}
-              {usdRate ? <span className="wallet-rate">@{usdRate.toFixed(2)}</span> : null}
-            </span>
-          </div>
-          <div className="wallet-address" title={walletAddress ?? ''}>
-            <span className="wallet-label">Кошелек</span>
-            <span className="wallet-hash">{walletAddress}</span>
-          </div>
-          <div className="wallet-actions">
-            <button
-              type="button"
-              className="wallet-button"
-              onClick={onTopUp}
-              disabled={walletLoading}
-            >
-              {walletLoading ? 'Обработка...' : 'Пополнить'}
-            </button>
-            <button
-              type="button"
-              className="wallet-button secondary"
-              onClick={onRefreshWallet}
-              disabled={walletLoading}
-            >
-              {walletLoading ? 'Обновление...' : 'Обновить'}
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove balance and wallet actions from the in-game score panel
- surface balance, wallet details, and actions on the nickname/bet overlay so they remain visible when it is open
- wire the nickname screen to receive wallet data and actions from the game view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d93bc9423483319eb2c2bff8ca8acf