### PR TITLE
Refine lobby screen layout and wallet tools

### DIFF
--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -1,4 +1,4 @@
-import { FormEvent } from 'react'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { formatNumber } from '../utils/helpers'
 import { SKINS, SKIN_LABELS } from '../hooks/useGame'
 
@@ -59,129 +59,216 @@ export function NicknameScreen({
     onStart()
   }
 
+  const derivedUsd = useMemo(() => {
+    if (typeof walletUsd === 'number') {
+      return walletUsd
+    }
+    if (typeof walletSol === 'number' && typeof usdRate === 'number') {
+      return walletSol * usdRate
+    }
+    return null
+  }, [usdRate, walletSol, walletUsd])
+
   const formattedSol = typeof walletSol === 'number' ? walletSol.toFixed(3) : '0.000'
-  const formattedUsd = typeof walletUsd === 'number' ? walletUsd.toFixed(2) : '—'
+  const formattedUsd = typeof derivedUsd === 'number' ? derivedUsd.toFixed(2) : '—'
   const showWallet = Boolean(walletAddress)
+
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle')
+  const copyResetTimer = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimer.current) {
+        window.clearTimeout(copyResetTimer.current)
+      }
+    }
+  }, [])
+
+  const resetCopyStatus = () => {
+    if (copyResetTimer.current) {
+      window.clearTimeout(copyResetTimer.current)
+    }
+    copyResetTimer.current = window.setTimeout(() => {
+      setCopyStatus('idle')
+    }, 2000)
+  }
+
+  const handleCopyWallet = async () => {
+    if (!walletAddress) return
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(walletAddress)
+      } else if (typeof document !== 'undefined') {
+        const textarea = document.createElement('textarea')
+        textarea.value = walletAddress
+        textarea.style.position = 'fixed'
+        textarea.style.opacity = '0'
+        document.body.appendChild(textarea)
+        textarea.focus()
+        textarea.select()
+        const successful = document.execCommand('copy')
+        document.body.removeChild(textarea)
+        if (!successful) {
+          throw new Error('Copy command failed')
+        }
+      } else {
+        throw new Error('Clipboard unavailable')
+      }
+      setCopyStatus('copied')
+    } catch (error) {
+      setCopyStatus('error')
+    } finally {
+      resetCopyStatus()
+    }
+  }
 
   return (
     <div id="nicknameScreen" className={visible ? 'overlay' : 'overlay hidden'}>
-      <div className="card">
-        <form onSubmit={handleSubmit}>
-          <h2>Slither — онлайн арена</h2>
-          <p>
-            Выберите никнейм и скин, чтобы начать игру. На компьютере управляйте мышью и удерживайте её кнопку, чтобы
-            ускориться. На смартфоне используйте виртуальный джойстик и кнопку ускорения.
-          </p>
-          <input
-            id="nicknameInput"
-            type="text"
-            maxLength={16}
-            placeholder="Ваш ник"
-            autoComplete="off"
-            value={nickname}
-            onChange={(event) => {
-              if (!nicknameLocked) {
-                onNicknameChange(event.target.value)
-              }
-            }}
-            disabled={nicknameLocked}
-          />
-          {nicknameLocked && (
-            <p className="nickname-note">Никнейм закреплён за аккаунтом.</p>
-          )}
-          <div className="skin-picker">
-            <div className="caption">
-              <span>Скины</span>
-              <span id="skinName">{skinName}</span>
-            </div>
-            <div id="skinList" className="skin-list">
-              {Object.entries(SKINS).map(([skin, colors]) => (
-                <button
-                  type="button"
-                  key={skin}
-                  className={`skin-option${skin === selectedSkin ? ' selected' : ''}`}
-                  data-skin={skin}
-                  data-name={SKIN_LABELS[skin] || skin}
-                  style={{ background: colors[0] ?? '#94a3b8', backgroundImage: 'none' }}
-                  onClick={() => onSelectSkin(skin)}
-                  aria-label={SKIN_LABELS[skin] || skin}
-                >
-                </button>
-              ))}
-            </div>
+      <div className="card lobby-card">
+        <form onSubmit={handleSubmit} className="lobby-form">
+          <div className="lobby-header">
+            <h2>Slither — онлайн арена</h2>
+            <p>
+              Выберите никнейм и скин, чтобы начать игру. На компьютере управляйте мышью и удерживайте её кнопку, чтобы
+              ускориться. На смартфоне используйте виртуальный джойстик и кнопку ускорения.
+            </p>
           </div>
-          <div className="account">
-            <div className="account-row">
-              <span className="account-label">Баланс</span>
-              <span className="account-value" id="balanceValue">
-                {formatNumber(balance)}
-              </span>
-            </div>
-            <div className="account-row">
-              <span className="account-label">Текущая ставка</span>
-              <span className="account-value">
-                {formatNumber(currentBet)}
-              </span>
-            </div>
+
+          <div className="lobby-grid">
+            <section className="lobby-panel lobby-panel-left">
+              <h3 className="lobby-title">Профиль</h3>
+              <label className="field-label" htmlFor="nicknameInput">
+                Никнейм
+              </label>
+              <input
+                id="nicknameInput"
+                type="text"
+                maxLength={16}
+                placeholder="Ваш ник"
+                autoComplete="off"
+                value={nickname}
+                onChange={(event) => {
+                  if (!nicknameLocked) {
+                    onNicknameChange(event.target.value)
+                  }
+                }}
+                disabled={nicknameLocked}
+              />
+              {nicknameLocked && (
+                <p className="nickname-note">Никнейм закреплён за аккаунтом.</p>
+              )}
+
+              <div className="skin-picker">
+                <div className="caption">
+                  <span>Скины</span>
+                  <span id="skinName">{skinName}</span>
+                </div>
+                <div id="skinList" className="skin-list">
+                  {Object.entries(SKINS).map(([skin, colors]) => (
+                    <button
+                      type="button"
+                      key={skin}
+                      className={`skin-option${skin === selectedSkin ? ' selected' : ''}`}
+                      data-skin={skin}
+                      data-name={SKIN_LABELS[skin] || skin}
+                      style={{ background: colors[0] ?? '#94a3b8', backgroundImage: 'none' }}
+                      onClick={() => onSelectSkin(skin)}
+                      aria-label={SKIN_LABELS[skin] || skin}
+                    >
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="lobby-panel lobby-panel-center">
+              <h3 className="lobby-title">Ставка</h3>
+              <div className="bet-control">
+                <label htmlFor="betInput">Ставка перед стартом</label>
+                <input
+                  id="betInput"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={betValue}
+                  onChange={(event) => onBetChange(event.target.value)}
+                  onBlur={onBetBlur}
+                />
+                <div className="bet-hint">
+                  Доступно: <span id="betBalanceDisplay">{formatNumber(balance)}</span>
+                </div>
+              </div>
+
+              <div className="account-row bet-summary">
+                <span className="account-label">Текущая ставка</span>
+                <span className="account-value">{formatNumber(currentBet)}</span>
+              </div>
+
+              <button id="startBtn" className="primary" type="submit" disabled={startDisabled} aria-disabled={startDisabled}>
+                {startLabel ?? 'Играть'}
+              </button>
+              {startDisabled && startDisabledHint && (
+                <p className="start-hint">{startDisabledHint}</p>
+              )}
+            </section>
+
+            <section className="lobby-panel lobby-panel-right">
+              <h3 className="lobby-title">Баланс</h3>
+              <div className="account">
+                <div className="account-row">
+                  <span className="account-label">Баланс</span>
+                  <span className="account-value" id="balanceValue">
+                    {formatNumber(balance)}
+                  </span>
+                </div>
+              </div>
+
+              {showWallet && (
+                <div className="wallet-section">
+                  <div className="wallet-row">
+                    <span className="wallet-label">SOL</span>
+                    <span className="wallet-value">{formattedSol}</span>
+                  </div>
+                  <div className="wallet-row">
+                    <span className="wallet-label">USD</span>
+                    <span className="wallet-value">{formattedUsd}</span>
+                  </div>
+                  <div className="wallet-address" title={walletAddress ?? ''}>
+                    <div className="wallet-address-text">
+                      <span className="wallet-label">Кошелек</span>
+                      <span className="wallet-hash">{walletAddress}</span>
+                    </div>
+                    <button
+                      type="button"
+                      className="wallet-copy-button"
+                      onClick={handleCopyWallet}
+                    >
+                      {copyStatus === 'copied' ? 'Скопировано' : copyStatus === 'error' ? 'Ошибка' : 'Скопировать'}
+                    </button>
+                  </div>
+                  <div className="wallet-actions">
+                    <button
+                      type="button"
+                      className="wallet-button"
+                      onClick={onTopUp}
+                      disabled={walletLoading}
+                    >
+                      {walletLoading ? 'Обработка...' : 'Пополнить'}
+                    </button>
+                    <button
+                      type="button"
+                      className="wallet-button secondary"
+                      onClick={onRefreshWallet}
+                      disabled={walletLoading}
+                    >
+                      {walletLoading ? 'Обновление...' : 'Обновить'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
           </div>
-          {showWallet && (
-            <div className="wallet-section">
-              <div className="wallet-row">
-                <span className="wallet-label">SOL</span>
-                <span className="wallet-value">{formattedSol}</span>
-              </div>
-              <div className="wallet-row">
-                <span className="wallet-label">USD</span>
-                <span className="wallet-value">
-                  {formattedUsd}
-                  {usdRate ? <span className="wallet-rate">@{usdRate.toFixed(2)}</span> : null}
-                </span>
-              </div>
-              <div className="wallet-address" title={walletAddress ?? ''}>
-                <span className="wallet-label">Кошелек</span>
-                <span className="wallet-hash">{walletAddress}</span>
-              </div>
-              <div className="wallet-actions">
-                <button
-                  type="button"
-                  className="wallet-button"
-                  onClick={onTopUp}
-                  disabled={walletLoading}
-                >
-                  {walletLoading ? 'Обработка...' : 'Пополнить'}
-                </button>
-                <button
-                  type="button"
-                  className="wallet-button secondary"
-                  onClick={onRefreshWallet}
-                  disabled={walletLoading}
-                >
-                  {walletLoading ? 'Обновление...' : 'Обновить'}
-                </button>
-              </div>
-            </div>
-          )}
-          <div className="bet-control">
-            <label htmlFor="betInput">Ставка перед стартом</label>
-            <input
-              id="betInput"
-              type="number"
-              min={1}
-              step={1}
-              value={betValue}
-              onChange={(event) => onBetChange(event.target.value)}
-              onBlur={onBetBlur}
-            />
-            <div className="bet-hint">
-              Доступно: <span id="betBalanceDisplay">{formatNumber(balance)}</span>
-            </div>
-          </div>
-          <button id="startBtn" className="primary" type="submit" disabled={startDisabled} aria-disabled={startDisabled}>
-            {startLabel ?? 'Играть'}
-          </button>
-          {startDisabled && startDisabledHint && (
-            <p className="start-hint">{startDisabledHint}</p>
-          )}
         </form>
       </div>
     </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -545,6 +545,194 @@
             width: min(420px, 90vw);
         }
 
+        .lobby-card {
+            width: min(1100px, 94vw);
+            text-align: left;
+        }
+
+        .lobby-card h2 {
+            text-align: left;
+        }
+
+        .lobby-card p {
+            text-align: left;
+        }
+
+        .lobby-form {
+            display: flex;
+            flex-direction: column;
+            gap: 28px;
+        }
+
+        .lobby-header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .lobby-grid {
+            display: grid;
+            gap: 20px;
+        }
+
+        @media (min-width: 768px) {
+            .lobby-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        @media (min-width: 1180px) {
+            .lobby-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+            }
+        }
+
+        .lobby-panel {
+            background: rgba(12, 19, 31, 0.7);
+            border: 1px solid rgba(94, 117, 151, 0.28);
+            border-radius: 20px;
+            padding: 20px 22px;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            min-height: 0;
+        }
+
+        .lobby-title {
+            margin: 0;
+            font-size: 15px;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: rgba(148, 163, 184, 0.72);
+        }
+
+        .field-label {
+            font-size: 14px;
+            font-weight: 600;
+            color: rgba(226, 232, 240, 0.9);
+            letter-spacing: 0.02em;
+        }
+
+        .lobby-panel .skin-picker {
+            margin-top: 4px;
+        }
+
+        .lobby-panel .nickname-note {
+            margin-bottom: 0;
+        }
+
+        .bet-summary {
+            margin-top: 12px;
+        }
+
+        .lobby-panel-center {
+            justify-content: flex-start;
+        }
+
+        .lobby-panel-center .primary {
+            margin-top: 6px;
+        }
+
+        .lobby-panel-center .start-hint {
+            margin-top: 12px;
+            margin-bottom: 0;
+            color: rgba(248, 250, 252, 0.7);
+            text-align: left;
+        }
+
+        .lobby-panel-right .wallet-section {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .lobby-panel-right .wallet-row {
+            font-size: 14px;
+        }
+
+        .lobby-panel-right .wallet-address {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            background: rgba(10, 18, 30, 0.65);
+            border: 1px solid rgba(59, 76, 103, 0.38);
+            border-radius: 14px;
+            padding: 12px 14px;
+        }
+
+        .wallet-address-text {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            flex: 1;
+            min-width: 0;
+        }
+
+        .wallet-address .wallet-hash {
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
+            color: rgba(226, 232, 240, 0.88);
+        }
+
+        .wallet-copy-button {
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            background: rgba(148, 163, 184, 0.18);
+            color: #e2e8f0;
+            border-radius: 12px;
+            padding: 8px 14px;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+            white-space: nowrap;
+        }
+
+        .wallet-copy-button:hover {
+            background: rgba(148, 163, 184, 0.32);
+            border-color: rgba(226, 232, 240, 0.4);
+            transform: translateY(-1px);
+        }
+
+        .wallet-copy-button:active {
+            transform: translateY(0);
+        }
+
+        .wallet-copy-button:disabled {
+            opacity: 0.6;
+            cursor: default;
+            transform: none;
+        }
+
+        .wallet-section .wallet-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .wallet-section .wallet-actions .wallet-button {
+            flex: 1;
+            min-width: 140px;
+        }
+
+        @media (max-width: 767px) {
+            .lobby-card {
+                padding: 24px 22px 28px;
+            }
+
+            .lobby-panel {
+                padding: 18px 16px;
+            }
+
+            .wallet-section .wallet-actions .wallet-button {
+                min-width: unset;
+            }
+        }
+
         .auth-card {
             width: min(420px, 92vw);
             max-width: 440px;


### PR DESCRIPTION
## Summary
- rearranged the nickname lobby into dedicated profile, stake, and balance panels with a responsive grid
- added wallet copy support and derive USD balances from SOL without displaying the conversion rate
- refreshed panel styling so the layout fits three columns on desktop and adapts cleanly on mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d93f291a1c8331832324a3ba146b7c