### PR TITLE
Add admin wallet transfer management

### DIFF
--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -19,6 +19,19 @@ interface AdminOverview {
   }
 }
 
+type TransferKind = 'game_to_user' | 'user_to_game' | 'user_to_user'
+
+const TRANSFER_ERROR_MESSAGES: Record<string, string> = {
+  invalid_amount: 'Некорректная сумма',
+  missing_destination_user_id: 'Выберите получателя',
+  missing_source_user_id: 'Выберите отправителя',
+  missing_user_id: 'Выберите отправителя и получателя',
+  insufficient_funds: 'Недостаточно средств на кошельке',
+  source_user_not_found: 'Отправитель не найден',
+  destination_user_not_found: 'Получатель не найден',
+  same_user_transfer: 'Нельзя переводить самому себе'
+}
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 const STORAGE_KEY = 'admin_basic_token'
 
@@ -32,6 +45,13 @@ export function AdminDashboard() {
   const [overview, setOverview] = useState<AdminOverview | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [transferKind, setTransferKind] = useState<TransferKind>('game_to_user')
+  const [transferFromUserId, setTransferFromUserId] = useState('')
+  const [transferToUserId, setTransferToUserId] = useState('')
+  const [transferAmount, setTransferAmount] = useState('')
+  const [transferLoading, setTransferLoading] = useState(false)
+  const [transferError, setTransferError] = useState<string | null>(null)
+  const [transferSuccess, setTransferSuccess] = useState<string | null>(null)
 
   const fetchOverview = useCallback(
     async (basicToken: string) => {
@@ -74,6 +94,17 @@ export function AdminDashboard() {
     }
   }, [fetchOverview, token])
 
+  useEffect(() => {
+    setTransferError(null)
+    setTransferSuccess(null)
+    if (transferKind === 'game_to_user') {
+      setTransferFromUserId('')
+    }
+    if (transferKind === 'user_to_game') {
+      setTransferToUserId('')
+    }
+  }, [transferKind])
+
   const handleSubmit = useCallback(
     async (event: FormEvent) => {
       event.preventDefault()
@@ -97,6 +128,86 @@ export function AdminDashboard() {
     if (!overview) return 0
     return overview.users.reduce((sum, user) => sum + (user.walletSol || 0), overview.gameWallet.walletSol || 0)
   }, [overview])
+
+  const userOptions = useMemo(() => overview?.users ?? [], [overview])
+
+  const handleTransfer = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault()
+      if (!token) return
+      const amountValue = Number(transferAmount)
+      if (!Number.isFinite(amountValue) || amountValue <= 0) {
+        setTransferError('Введите корректную сумму')
+        setTransferSuccess(null)
+        return
+      }
+
+      const payload: Record<string, unknown> = { amount: amountValue }
+
+      if (transferKind === 'game_to_user') {
+        if (!transferToUserId) {
+          setTransferError('Выберите получателя')
+          setTransferSuccess(null)
+          return
+        }
+        payload.fromType = 'game'
+        payload.toType = 'user'
+        payload.toUserId = Number(transferToUserId)
+      } else if (transferKind === 'user_to_game') {
+        if (!transferFromUserId) {
+          setTransferError('Выберите отправителя')
+          setTransferSuccess(null)
+          return
+        }
+        payload.fromType = 'user'
+        payload.toType = 'game'
+        payload.fromUserId = Number(transferFromUserId)
+      } else {
+        if (!transferFromUserId || !transferToUserId) {
+          setTransferError('Выберите отправителя и получателя')
+          setTransferSuccess(null)
+          return
+        }
+        if (transferFromUserId === transferToUserId) {
+          setTransferError('Нельзя переводить самому себе')
+          setTransferSuccess(null)
+          return
+        }
+        payload.fromType = 'user'
+        payload.toType = 'user'
+        payload.fromUserId = Number(transferFromUserId)
+        payload.toUserId = Number(transferToUserId)
+      }
+
+      setTransferLoading(true)
+      setTransferError(null)
+      setTransferSuccess(null)
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/admin/transfer`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Basic ${token}`
+          },
+          body: JSON.stringify(payload)
+        })
+        const data = await res.json().catch(() => null)
+        if (!res.ok) {
+          const message = data?.error || 'transfer_failed'
+          throw new Error(message)
+        }
+        setTransferSuccess('Перевод выполнен')
+        setTransferAmount('')
+        await fetchOverview(token)
+      } catch (err) {
+        const code = (err as Error).message || 'transfer_failed'
+        setTransferError(TRANSFER_ERROR_MESSAGES[code] || code)
+      } finally {
+        setTransferLoading(false)
+      }
+    },
+    [fetchOverview, token, transferAmount, transferFromUserId, transferKind, transferToUserId]
+  )
 
   if (!token || !overview) {
     return (
@@ -154,6 +265,61 @@ export function AdminDashboard() {
             <span className="summary-label">Всего SOL</span>
             <span className="summary-value">{totalSol.toFixed(3)} SOL</span>
           </div>
+        </div>
+        <div className="admin-transfer">
+          <h2>Переводы</h2>
+          <form onSubmit={handleTransfer}>
+            <label>
+              Тип перевода
+              <select value={transferKind} onChange={(event) => setTransferKind(event.target.value as TransferKind)}>
+                <option value="game_to_user">Игровой кошелек → Пользователь</option>
+                <option value="user_to_game">Пользователь → Игровой кошелек</option>
+                <option value="user_to_user">Пользователь → Пользователь</option>
+              </select>
+            </label>
+            {(transferKind === 'user_to_game' || transferKind === 'user_to_user') && (
+              <label>
+                Отправитель
+                <select value={transferFromUserId} onChange={(event) => setTransferFromUserId(event.target.value)}>
+                  <option value="">Выберите пользователя</option>
+                  {userOptions.map((user) => (
+                    <option key={user.id} value={user.id}>
+                      #{user.id} · {user.email}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            {(transferKind === 'game_to_user' || transferKind === 'user_to_user') && (
+              <label>
+                Получатель
+                <select value={transferToUserId} onChange={(event) => setTransferToUserId(event.target.value)}>
+                  <option value="">Выберите пользователя</option>
+                  {userOptions.map((user) => (
+                    <option key={user.id} value={user.id}>
+                      #{user.id} · {user.email}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <label>
+              Сумма (в условных единицах)
+              <input
+                type="number"
+                min="0"
+                step="0.001"
+                value={transferAmount}
+                onChange={(event) => setTransferAmount(event.target.value)}
+                required
+              />
+            </label>
+            <button type="submit" disabled={transferLoading}>
+              {transferLoading ? 'Выполнение...' : 'Перевести'}
+            </button>
+            {transferError && <div className="admin-error">Ошибка: {transferError}</div>}
+            {transferSuccess && <div className="admin-success">{transferSuccess}</div>}
+          </form>
         </div>
         <div className="admin-table">
           <table>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -374,6 +374,79 @@
             padding: 16px 20px;
         }
 
+        .admin-transfer {
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            border-radius: 18px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .admin-transfer h2 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 600;
+            color: #f8fafc;
+        }
+
+        .admin-transfer form {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+            align-items: end;
+        }
+
+        .admin-transfer label {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 13px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: rgba(148, 163, 184, 0.85);
+        }
+
+        .admin-transfer select,
+        .admin-transfer input {
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            background: rgba(15, 23, 42, 0.55);
+            color: #f8fafc;
+        }
+
+        .admin-transfer button {
+            padding: 12px;
+            border-radius: 12px;
+            border: none;
+            background: linear-gradient(135deg, #38bdf8, #2563eb);
+            color: #fff;
+            font-size: 14px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .admin-transfer button:disabled {
+            opacity: 0.7;
+            cursor: default;
+        }
+
+        .admin-success {
+            grid-column: 1 / -1;
+            padding: 8px 12px;
+            border-radius: 10px;
+            background: rgba(34, 197, 94, 0.18);
+            color: #bbf7d0;
+            font-size: 13px;
+        }
+
+        .admin-transfer .admin-error,
+        .admin-transfer .admin-success {
+            margin-top: 0;
+        }
+
         .summary-label {
             display: block;
             font-size: 12px;


### PR DESCRIPTION
## Summary
- add an authenticated admin API endpoint to perform wallet-to-wallet transfers
- extend the wallet service with user-to-user transfer support and expose it to the admin portal
- update the admin dashboard UI with transfer controls, validation, and styling for managing balances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97ed26acc83318465c99bb78bb235