### PR TITLE
Revamp lobby hero layout

### DIFF
--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -196,34 +196,47 @@ export function NicknameScreen({
       <div className="card lobby-card">
         <div className="lobby-hero">
           <div className="lobby-hero-copy">
-            <span className="lobby-badge">Real-time bet arena</span>
-            <h2>Slither X — арена мгновенных ставок</h2>
-            <p>
-              Управляйте своим змеем, удерживайте зону и фиксируйте прибыль. Плавная камера, мягкая анимация хвоста и
-              киберпанковая атмосфера создают профессиональный опыт для хардкорных игроков.
-            </p>
+            <div className="lobby-logo" aria-label="Slither X">
+              <span className="lobby-logo-main">Slither</span>
+              <span className="lobby-logo-accent">X</span>
+            </div>
+            <p className="lobby-tagline">Неоновая арена мгновенных ставок.</p>
+            <div className="lobby-hero-status">
+              <span className="status-chip">
+                <span className="status-dot" /> online
+              </span>
+              <span className="status-divider" />
+              <span className="status-text">Залетай и забирай банк.</span>
+            </div>
             <div className="lobby-hero-metrics">
-              <div className="metric">
+              <div className="metric metric--balance">
+                <span className="metric-label">Баланс</span>
                 <span className="metric-value">{formatNumber(balance)}</span>
-                <span className="metric-label">Ваш баланс</span>
               </div>
-              <div className="metric">
+              <div className="metric metric--bet">
+                <span className="metric-label">Ставка</span>
                 <span className="metric-value">{formatNumber(currentBet)}</span>
-                <span className="metric-label">Активная ставка</span>
               </div>
-              <div className="metric">
+              <div className="metric metric--skin">
+                <span className="metric-label">Скин</span>
                 <span className="metric-value">{skinName}</span>
-                <span className="metric-label">Выбранный скин</span>
               </div>
             </div>
           </div>
           <div className="lobby-hero-visual" aria-hidden="true">
-            <div className="hero-orb hero-orb-primary" />
-            <div className="hero-orb hero-orb-secondary" />
-            <div className="hero-grid">
-              <span>Плавный геймплей</span>
-              <span>Solana-ready</span>
-              <span>Прозрачные ставки</span>
+            <div className="lobby-hero-arena">
+              <div className="arena-glow" />
+              <div className="arena-ring" />
+              <div className="arena-ring arena-ring--secondary" />
+              <div className="arena-snake">
+                <span className="arena-snake-head" />
+              </div>
+              <div className="arena-scanline" />
+              <div className="arena-scanline arena-scanline--alt" />
+            </div>
+            <div className="hero-indicator">
+              <span className="indicator-label">Ставки активны</span>
+              <span className="indicator-value">{formatNumber(currentBet)}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -14,8 +14,9 @@
         html,
         body {
             margin: 0;
-            height: 100%;
-            overflow: hidden;
+            min-height: 100vh;
+            overflow-x: hidden;
+            overflow-y: auto;
             background:
                 radial-gradient(circle at 12% 18%, rgba(34, 211, 238, 0.22), transparent 42%),
                 radial-gradient(circle at 78% 12%, rgba(56, 189, 248, 0.26), transparent 48%),
@@ -816,6 +817,8 @@
             background: rgba(2, 6, 23, 0.78);
             backdrop-filter: blur(38px);
             z-index: 10;
+            min-height: 100vh;
+            overflow-y: auto;
         }
 
         .overlay::before {
@@ -938,26 +941,30 @@
             }
         }
 
+
         .lobby-hero {
             position: relative;
             display: grid;
-            gap: clamp(24px, 4vw, 40px);
-            padding: clamp(22px, 3.4vw, 34px);
-            border-radius: 28px;
-            background: linear-gradient(160deg, rgba(8, 14, 30, 0.82), rgba(17, 24, 52, 0.9));
-            border: 1px solid rgba(96, 165, 250, 0.22);
+            gap: clamp(22px, 3.5vw, 38px);
+            padding: clamp(24px, 3.6vw, 36px);
+            border-radius: 30px;
+            background:
+                radial-gradient(circle at 10% 20%, rgba(34, 197, 94, 0.16), transparent 55%),
+                radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.18), transparent 60%),
+                linear-gradient(160deg, rgba(8, 16, 32, 0.88), rgba(11, 23, 52, 0.96));
+            border: 1px solid rgba(74, 222, 128, 0.14);
             overflow: hidden;
         }
 
         .lobby-hero::before {
             content: "";
             position: absolute;
-            inset: -40% 40% auto -20%;
-            width: 320px;
-            height: 320px;
-            background: radial-gradient(circle, rgba(59, 130, 246, 0.28), rgba(59, 130, 246, 0));
-            filter: blur(32px);
-            opacity: 0.6;
+            inset: -40% 30% auto -30%;
+            width: 360px;
+            height: 360px;
+            background: radial-gradient(circle, rgba(74, 222, 128, 0.32), rgba(74, 222, 128, 0));
+            filter: blur(38px);
+            opacity: 0.65;
             pointer-events: none;
         }
 
@@ -965,11 +972,11 @@
             content: "";
             position: absolute;
             inset: auto -30% -40% auto;
-            width: 260px;
-            height: 260px;
-            background: radial-gradient(circle, rgba(56, 189, 248, 0.26), rgba(56, 189, 248, 0));
-            filter: blur(24px);
-            opacity: 0.55;
+            width: 320px;
+            height: 320px;
+            background: radial-gradient(circle, rgba(129, 140, 248, 0.32), rgba(129, 140, 248, 0));
+            filter: blur(32px);
+            opacity: 0.6;
             pointer-events: none;
         }
 
@@ -983,146 +990,311 @@
         .lobby-hero-copy {
             display: flex;
             flex-direction: column;
-            gap: clamp(14px, 2.4vw, 22px);
+            gap: clamp(16px, 2.4vw, 28px);
             position: relative;
             z-index: 1;
         }
 
-        .lobby-badge {
+        .lobby-logo {
             display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 6px 16px;
-            border-radius: 999px;
-            background: linear-gradient(135deg, rgba(59, 130, 246, 0.28), rgba(96, 165, 250, 0.16));
-            border: 1px solid rgba(59, 130, 246, 0.45);
-            font-size: 11px;
-            letter-spacing: 0.24em;
+            align-items: flex-end;
+            gap: 12px;
             text-transform: uppercase;
-            color: rgba(224, 242, 254, 0.88);
-            box-shadow: 0 12px 28px rgba(59, 130, 246, 0.22);
+            font-weight: 800;
+            letter-spacing: 0.06em;
         }
 
-        .lobby-hero-copy h2 {
-            margin: 0;
-            font-size: clamp(28px, 4vw, 44px);
-            font-weight: 800;
-            letter-spacing: -0.02em;
-            background: linear-gradient(120deg, #f8fafc, #bae6fd 45%, #c4b5fd 90%);
+        .lobby-logo-main {
+            font-size: clamp(30px, 5vw, 48px);
+            background: linear-gradient(120deg, #f8fafc, #a5f3fc 50%, #bbf7d0 95%);
             -webkit-background-clip: text;
             background-clip: text;
             color: transparent;
-            text-shadow: 0 0 30px rgba(59, 130, 246, 0.2);
+            text-shadow: 0 0 26px rgba(34, 197, 94, 0.35);
         }
 
-        .lobby-hero-copy p {
+        .lobby-logo-accent {
+            font-size: clamp(36px, 6vw, 54px);
+            color: #4ade80;
+            text-shadow:
+                0 0 18px rgba(74, 222, 128, 0.6),
+                0 0 38px rgba(59, 130, 246, 0.35);
+            transform: translateY(4px);
+        }
+
+        .lobby-tagline {
             margin: 0;
-            max-width: 600px;
-            color: rgba(191, 219, 254, 0.82);
-            line-height: 1.7;
-            font-size: clamp(15px, 2vw, 17px);
-            letter-spacing: 0.01em;
+            max-width: 520px;
+            font-size: clamp(16px, 2.3vw, 20px);
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            color: rgba(226, 232, 240, 0.88);
+            text-transform: uppercase;
+        }
+
+        .lobby-hero-status {
+            display: inline-flex;
+            align-items: center;
+            gap: 14px;
+            font-size: 13px;
+            letter-spacing: 0.24em;
+            text-transform: uppercase;
+            color: rgba(148, 197, 255, 0.78);
+        }
+
+        .status-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 18px;
+            border-radius: 999px;
+            background: rgba(34, 197, 94, 0.14);
+            border: 1px solid rgba(34, 197, 94, 0.45);
+            box-shadow:
+                0 12px 24px rgba(34, 197, 94, 0.2),
+                inset 0 0 18px rgba(59, 130, 246, 0.18);
+        }
+
+        .status-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #4ade80;
+            box-shadow: 0 0 12px rgba(74, 222, 128, 0.8);
+        }
+
+        .status-divider {
+            display: inline-block;
+            width: 36px;
+            height: 1px;
+            background: linear-gradient(90deg, rgba(148, 163, 184, 0.1), rgba(148, 163, 184, 0.6), rgba(148, 163, 184, 0.1));
+        }
+
+        .status-text {
+            color: rgba(226, 232, 240, 0.72);
         }
 
         .lobby-hero-metrics {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 14px;
-            margin-top: 4px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 16px;
         }
 
         .metric {
-            min-width: 160px;
-            padding: 14px 18px;
-            border-radius: 18px;
-            background: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(37, 99, 235, 0.18));
-            border: 1px solid rgba(37, 99, 235, 0.3);
+            position: relative;
+            padding: 18px 20px;
+            border-radius: 20px;
+            border: 1px solid rgba(59, 130, 246, 0.28);
+            background:
+                linear-gradient(150deg, rgba(15, 23, 42, 0.85), rgba(8, 47, 73, 0.45)),
+                radial-gradient(circle at 0% 0%, rgba(34, 197, 94, 0.25), transparent 65%);
             display: flex;
             flex-direction: column;
-            gap: 6px;
-            box-shadow: inset 0 0 24px rgba(37, 99, 235, 0.16);
+            gap: 10px;
+            box-shadow: inset 0 0 28px rgba(59, 130, 246, 0.18);
+            overflow: hidden;
         }
 
-        .metric-value {
-            font-size: clamp(20px, 3vw, 26px);
-            font-weight: 700;
-            color: #f0f9ff;
-            text-shadow: 0 0 18px rgba(56, 189, 248, 0.3);
+        .metric::after {
+            content: "";
+            position: absolute;
+            inset: 40% -30% -40% auto;
+            background: radial-gradient(circle, rgba(56, 189, 248, 0.18), transparent 70%);
+            opacity: 0.7;
+            pointer-events: none;
         }
 
         .metric-label {
-            font-size: 11px;
-            letter-spacing: 0.2em;
+            font-size: 12px;
+            letter-spacing: 0.28em;
             text-transform: uppercase;
             color: rgba(148, 197, 255, 0.68);
         }
 
+        .metric-value {
+            font-size: clamp(22px, 3.2vw, 28px);
+            font-weight: 700;
+            color: #f0fdf4;
+            text-shadow: 0 0 24px rgba(34, 197, 94, 0.45);
+        }
+
+        .metric--balance {
+            border-color: rgba(34, 197, 94, 0.45);
+            box-shadow:
+                inset 0 0 28px rgba(34, 197, 94, 0.18),
+                0 18px 32px rgba(34, 197, 94, 0.18);
+        }
+
+        .metric--bet {
+            border-color: rgba(59, 130, 246, 0.45);
+            box-shadow:
+                inset 0 0 32px rgba(59, 130, 246, 0.22),
+                0 18px 30px rgba(59, 130, 246, 0.14);
+        }
+
+        .metric--skin {
+            border-color: rgba(236, 72, 153, 0.45);
+            box-shadow:
+                inset 0 0 32px rgba(236, 72, 153, 0.2),
+                0 18px 28px rgba(236, 72, 153, 0.16);
+        }
+
         .lobby-hero-visual {
             position: relative;
-            min-height: 220px;
+            min-height: 240px;
             border-radius: 26px;
             overflow: hidden;
-            background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(30, 58, 138, 0.4));
-            border: 1px solid rgba(59, 130, 246, 0.25);
+            border: 1px solid rgba(59, 130, 246, 0.35);
+            background: radial-gradient(circle at 50% 20%, rgba(34, 211, 238, 0.18), transparent 60%),
+                linear-gradient(160deg, rgba(8, 16, 32, 0.92), rgba(17, 25, 58, 0.8));
             display: flex;
+            flex-direction: column;
             align-items: flex-end;
-            justify-content: center;
+            justify-content: flex-end;
             padding: 24px;
-            box-shadow: inset 0 0 24px rgba(59, 130, 246, 0.18);
+            box-shadow: inset 0 0 32px rgba(56, 189, 248, 0.16);
         }
 
-        .hero-orb {
+        .lobby-hero-arena {
             position: absolute;
-            border-radius: 999px;
-            filter: blur(0px);
-            opacity: 0.9;
-        }
-
-        .hero-orb-primary {
-            width: 220px;
-            height: 220px;
-            top: -60px;
-            right: -40px;
-            background: radial-gradient(circle, rgba(59, 130, 246, 0.48), rgba(59, 130, 246, 0));
-        }
-
-        .hero-orb-secondary {
-            width: 180px;
-            height: 180px;
-            bottom: -40px;
-            left: -30px;
-            background: radial-gradient(circle, rgba(45, 212, 191, 0.42), rgba(45, 212, 191, 0));
-        }
-
-        .hero-grid {
-            position: relative;
-            z-index: 1;
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            gap: 12px;
-            font-size: 12px;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
-            color: rgba(226, 232, 240, 0.78);
-        }
-
-        .hero-grid span {
+            inset: 0;
             display: flex;
             align-items: center;
             justify-content: center;
-            padding: 12px 10px;
-            border-radius: 14px;
-            background: linear-gradient(145deg, rgba(15, 23, 42, 0.65), rgba(37, 99, 235, 0.24));
-            border: 1px solid rgba(96, 165, 250, 0.25);
-            box-shadow: 0 12px 30px rgba(37, 99, 235, 0.22);
+            overflow: hidden;
         }
 
-        @media (max-width: 620px) {
-            .hero-grid {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
+        .arena-glow {
+            position: absolute;
+            width: 80%;
+            height: 80%;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(56, 189, 248, 0.4), rgba(56, 189, 248, 0));
+            filter: blur(20px);
+            opacity: 0.6;
+        }
+
+        @keyframes arenaSpin {
+            from {
+                transform: rotate(0deg);
+            }
+
+            to {
+                transform: rotate(360deg);
             }
         }
 
+        .arena-ring {
+            position: absolute;
+            width: 70%;
+            height: 70%;
+            border-radius: 50%;
+            border: 1.6px solid rgba(148, 197, 255, 0.32);
+            box-shadow: 0 0 30px rgba(59, 130, 246, 0.35);
+            animation: arenaSpin 18s linear infinite;
+        }
+
+        .arena-ring--secondary {
+            width: 52%;
+            height: 52%;
+            border-color: rgba(74, 222, 128, 0.4);
+            animation-duration: 12s;
+            animation-direction: reverse;
+            opacity: 0.8;
+        }
+
+        @keyframes snakePulse {
+            0%,
+            100% {
+                transform: scale(0.88) rotate(2deg);
+                box-shadow: 0 0 30px rgba(74, 222, 128, 0.3);
+            }
+
+            50% {
+                transform: scale(1) rotate(-2deg);
+                box-shadow: 0 0 40px rgba(56, 189, 248, 0.35);
+            }
+        }
+
+        .arena-snake {
+            position: relative;
+            width: 58%;
+            height: 58%;
+            border-radius: 50% 42% 50% 52% / 60% 55% 45% 40%;
+            background: radial-gradient(circle at 30% 30%, rgba(34, 197, 94, 0.45), transparent 70%),
+                conic-gradient(from 120deg, rgba(59, 130, 246, 0.4), rgba(236, 72, 153, 0.35), rgba(74, 222, 128, 0.4), rgba(59, 130, 246, 0.4));
+            filter: saturate(120%);
+            animation: snakePulse 6s ease-in-out infinite;
+            box-shadow: inset 0 0 40px rgba(8, 145, 178, 0.3);
+        }
+
+        .arena-snake-head {
+            position: absolute;
+            top: 18%;
+            right: 14%;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            background: radial-gradient(circle, #fef9c3, #f97316 70%);
+            box-shadow:
+                0 0 16px rgba(250, 204, 21, 0.6),
+                0 0 32px rgba(234, 179, 8, 0.45);
+        }
+
+        @keyframes arenaScan {
+            0% {
+                transform: translateY(-60%) skewX(-12deg);
+            }
+
+            100% {
+                transform: translateY(140%) skewX(-12deg);
+            }
+        }
+
+        .arena-scanline {
+            position: absolute;
+            width: 120%;
+            height: 2px;
+            background: linear-gradient(90deg, transparent, rgba(148, 197, 255, 0.8), transparent);
+            opacity: 0.55;
+            animation: arenaScan 4.4s linear infinite;
+        }
+
+        .arena-scanline--alt {
+            animation-delay: 1.6s;
+            opacity: 0.4;
+        }
+
+        .hero-indicator {
+            position: relative;
+            z-index: 2;
+            display: inline-flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 4px;
+            padding: 14px 18px;
+            border-radius: 16px;
+            background: rgba(2, 6, 23, 0.6);
+            border: 1px solid rgba(59, 130, 246, 0.32);
+            backdrop-filter: blur(20px);
+            box-shadow:
+                0 12px 30px rgba(15, 23, 42, 0.5),
+                inset 0 0 22px rgba(59, 130, 246, 0.2);
+        }
+
+        .indicator-label {
+            font-size: 11px;
+            letter-spacing: 0.3em;
+            text-transform: uppercase;
+            color: rgba(148, 197, 255, 0.68);
+        }
+
+        .indicator-value {
+            font-size: 20px;
+            font-weight: 700;
+            color: #f0fdf4;
+            text-shadow: 0 0 18px rgba(74, 222, 128, 0.4);
+        }
         .lobby-panel {
             position: relative;
             background: linear-gradient(165deg, rgba(10, 18, 34, 0.85), rgba(15, 23, 42, 0.92));


### PR DESCRIPTION
## Summary
- redesign the lobby hero with a neon arcade presentation, new logo treatment, and animated arena backdrop
- refresh metric tiles and supporting copy to focus on core data points without long-form descriptions
- allow the lobby overlay to scroll vertically so the full form remains usable on shorter viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6561f2288331b08a2fa83fd8a71d