### PR TITLE
Redesign lobby desktop layout

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -942,24 +942,18 @@
         .lobby-card {
             position: relative;
             width: 100%;
-            max-width: min(1140px, 100%);
+            max-width: min(1280px, 100%);
             margin: 0 auto;
-            display: grid;
+            display: flex;
+            flex-direction: column;
             gap: clamp(20px, 3vw, 32px);
-            background: linear-gradient(165deg, rgba(2, 10, 25, 0.6), rgba(12, 27, 52, 0.75));
-            border-radius: 32px;
-            padding: clamp(24px, 3.5vw, 36px);
+            background: linear-gradient(165deg, rgba(2, 10, 25, 0.6), rgba(12, 27, 52, 0.78));
+            border-radius: 36px;
+            padding: clamp(24px, 3.5vw, 40px);
             border: 1px solid rgba(37, 99, 235, 0.22);
             box-shadow:
                 0 30px 80px rgba(15, 23, 42, 0.55),
                 inset 0 0 0 1px rgba(148, 163, 184, 0.08);
-        }
-
-        @media (min-width: 1080px) {
-            .lobby-card {
-                grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-                align-items: stretch;
-            }
         }
 
         .lobby-card::before {
@@ -977,20 +971,516 @@
         .lobby-form {
             display: flex;
             flex-direction: column;
-            gap: clamp(18px, 2.4vw, 26px);
-            height: 100%;
+            gap: clamp(20px, 2.8vw, 28px);
         }
 
-        .lobby-grid {
+        .lobby-header {
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        @media (min-width: 720px) {
+            .lobby-header {
+                flex-direction: row;
+                align-items: center;
+                justify-content: space-between;
+                gap: clamp(20px, 5vw, 40px);
+            }
+        }
+
+        .lobby-header-brand {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .lobby-header-profile {
+            display: inline-flex;
+            align-items: center;
+            gap: 14px;
+            padding: 12px 18px;
+            border-radius: 24px;
+            border: 1px solid rgba(59, 130, 246, 0.26);
+            background: linear-gradient(150deg, rgba(12, 23, 51, 0.65), rgba(15, 23, 42, 0.85));
+            box-shadow:
+                inset 0 0 32px rgba(59, 130, 246, 0.18),
+                0 18px 38px rgba(15, 23, 42, 0.45);
+        }
+
+        .profile-avatar {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
             display: grid;
-            gap: clamp(16px, 2.2vw, 24px);
-            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            place-items: center;
+            color: #0f172a;
+            font-weight: 700;
+            font-size: 20px;
+            text-transform: uppercase;
+            box-shadow:
+                0 0 0 2px rgba(241, 245, 249, 0.18),
+                0 12px 26px rgba(148, 163, 184, 0.22);
         }
 
-        @media (min-width: 1024px) {
-            .lobby-grid {
+        .profile-details {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .profile-label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+            color: rgba(148, 197, 255, 0.7);
+        }
+
+        .profile-name {
+            font-size: 18px;
+            font-weight: 700;
+            color: #f8fafc;
+        }
+
+        .lobby-layout {
+            display: grid;
+            gap: clamp(18px, 2.6vw, 28px);
+        }
+
+        @media (min-width: 960px) {
+            .lobby-layout {
                 grid-template-columns: repeat(2, minmax(0, 1fr));
             }
+        }
+
+        @media (min-width: 1240px) {
+            .lobby-layout {
+                grid-template-columns: minmax(260px, 1fr) minmax(340px, 1.15fr) minmax(280px, 1fr);
+                align-items: start;
+            }
+        }
+
+        .lobby-column {
+            display: flex;
+            flex-direction: column;
+            gap: clamp(16px, 2.4vw, 22px);
+        }
+
+        .lobby-column-center {
+            align-items: center;
+            text-align: center;
+        }
+
+        .glass-card {
+            position: relative;
+            border-radius: 28px;
+            padding: clamp(18px, 2.5vw, 24px);
+            border: 1px solid rgba(59, 130, 246, 0.22);
+            background:
+                linear-gradient(150deg, rgba(12, 21, 42, 0.78), rgba(15, 23, 42, 0.92)),
+                radial-gradient(circle at 0% 0%, rgba(96, 165, 250, 0.25), transparent 60%);
+            box-shadow:
+                inset 0 0 0 1px rgba(148, 163, 184, 0.12),
+                0 24px 60px rgba(2, 6, 23, 0.55);
+        }
+
+        .glass-card::before {
+            content: "";
+            position: absolute;
+            inset: -40% auto auto -30%;
+            width: 220px;
+            height: 220px;
+            background: radial-gradient(circle, rgba(96, 165, 250, 0.25), transparent 70%);
+            filter: blur(32px);
+            opacity: 0.6;
+            pointer-events: none;
+        }
+
+        .balance-widget {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .balance-widget-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .balance-widget-title {
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.24em;
+            color: rgba(148, 197, 255, 0.78);
+        }
+
+        .balance-widget-value {
+            font-size: clamp(36px, 6vw, 52px);
+            font-weight: 800;
+            line-height: 1;
+            color: #f8fafc;
+            text-shadow: 0 0 32px rgba(56, 189, 248, 0.4);
+        }
+
+        .balance-widget-meta {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+            color: rgba(148, 163, 184, 0.88);
+        }
+
+        .balance-widget-meta strong {
+            font-size: 16px;
+            font-weight: 700;
+            color: #f8fafc;
+        }
+
+        .balance-wallet {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            padding: 12px 16px;
+            border-radius: 20px;
+            background: linear-gradient(140deg, rgba(15, 118, 110, 0.24), rgba(8, 47, 73, 0.35));
+            border: 1px solid rgba(45, 212, 191, 0.25);
+            box-shadow: inset 0 0 32px rgba(13, 148, 136, 0.18);
+        }
+
+        .wallet-amount {
+            font-size: 14px;
+            font-weight: 600;
+            color: #ccfbf1;
+        }
+
+        .wallet-amount.usd {
+            color: #bae6fd;
+        }
+
+        .icon-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            border-radius: 14px;
+            border: 1px solid rgba(148, 163, 184, 0.24);
+            background: rgba(15, 23, 42, 0.6);
+            color: #e2e8f0;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .icon-button:hover:not(:disabled),
+        .icon-button:focus-visible:not(:disabled) {
+            border-color: rgba(96, 165, 250, 0.6);
+            box-shadow: 0 12px 28px rgba(59, 130, 246, 0.18);
+        }
+
+        .icon-button:disabled {
+            opacity: 0.5;
+            cursor: default;
+        }
+
+        .icon-wallet {
+            width: 18px;
+            height: 18px;
+            border-radius: 4px;
+            background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(59, 130, 246, 0.85));
+            box-shadow: 0 0 12px rgba(59, 130, 246, 0.5);
+        }
+
+        .auth-link {
+            align-self: flex-start;
+            padding: 10px 18px;
+            border-radius: 18px;
+            border: 1px solid rgba(56, 189, 248, 0.45);
+            background: linear-gradient(135deg, rgba(37, 99, 235, 0.5), rgba(14, 165, 233, 0.45));
+            color: #f8fafc;
+            font-weight: 600;
+            text-decoration: none;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .auth-link:hover,
+        .auth-link:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 28px rgba(56, 189, 248, 0.25);
+        }
+
+        .utility-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 16px;
+        }
+
+        .utility-card {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 18px 20px;
+            cursor: pointer;
+            text-align: left;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+        }
+
+        .utility-card:hover,
+        .utility-card:focus-visible {
+            transform: translateY(-2px);
+            border-color: rgba(147, 197, 253, 0.5);
+            box-shadow: 0 18px 36px rgba(30, 64, 175, 0.25);
+        }
+
+        .utility-card:disabled {
+            cursor: default;
+            opacity: 0.6;
+            transform: none;
+            box-shadow: none;
+        }
+
+        .utility-icon {
+            width: 42px;
+            height: 42px;
+            border-radius: 16px;
+            background: rgba(59, 130, 246, 0.2);
+            position: relative;
+            box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.35);
+        }
+
+        .utility-icon::before,
+        .utility-icon::after {
+            content: "";
+            position: absolute;
+            inset: 14px;
+            border-radius: 50%;
+            background: rgba(59, 130, 246, 0.65);
+        }
+
+        .utility-icon--stats {
+            background: rgba(16, 185, 129, 0.2);
+            box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.45);
+        }
+
+        .utility-icon--stats::before {
+            inset: 12px 10px;
+            border-radius: 6px;
+            background: linear-gradient(180deg, rgba(94, 234, 212, 0.9), rgba(16, 185, 129, 0.75));
+        }
+
+        .utility-icon--leaders {
+            background: rgba(236, 72, 153, 0.22);
+            box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.45);
+        }
+
+        .utility-icon--leaders::before {
+            inset: 12px;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(251, 191, 36, 0.9), rgba(236, 72, 153, 0.6));
+        }
+
+        .utility-content {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .utility-label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+            color: rgba(148, 197, 255, 0.72);
+        }
+
+        .utility-value {
+            font-size: 16px;
+            font-weight: 600;
+            color: #f8fafc;
+        }
+
+        .utility-subvalue {
+            margin-left: auto;
+            font-size: 13px;
+            color: rgba(148, 163, 184, 0.85);
+        }
+
+        .utility-lock {
+            width: 14px;
+            height: 18px;
+            border-radius: 4px;
+            background: linear-gradient(135deg, rgba(148, 163, 184, 0.5), rgba(71, 85, 105, 0.6));
+            margin-left: auto;
+        }
+
+        .arena-card {
+            width: min(440px, 100%);
+            aspect-ratio: 1 / 1;
+            display: grid;
+            place-items: center;
+            overflow: hidden;
+            isolation: isolate;
+            background: radial-gradient(circle at 30% 20%, rgba(59, 130, 246, 0.25), transparent 60%);
+        }
+
+        .arena-card::after {
+            content: "";
+            position: absolute;
+            inset: 20%;
+            border-radius: 50%;
+            border: 1px solid rgba(148, 197, 255, 0.25);
+            filter: blur(12px);
+        }
+
+        @keyframes arenaGradient {
+            0% {
+                transform: translate(-10%, -10%) scale(1);
+            }
+
+            50% {
+                transform: translate(10%, 6%) scale(1.08);
+            }
+
+            100% {
+                transform: translate(-10%, -10%) scale(1);
+            }
+        }
+
+        .arena-backdrop {
+            position: absolute;
+            inset: -20%;
+            background: radial-gradient(circle at 40% 40%, var(--arena-primary), transparent 65%),
+                radial-gradient(circle at 70% 70%, var(--arena-secondary), transparent 70%);
+            filter: blur(60px);
+            opacity: 0.9;
+            animation: arenaGradient 12s ease-in-out infinite;
+        }
+
+        .arena-halo {
+            position: absolute;
+            inset: 12%;
+            border-radius: 50%;
+            border: 2px solid rgba(148, 197, 255, 0.35);
+            box-shadow:
+                0 0 60px rgba(59, 130, 246, 0.35),
+                inset 0 0 40px rgba(59, 130, 246, 0.25);
+        }
+
+        .arena-character {
+            position: relative;
+            width: 56%;
+            aspect-ratio: 1 / 1;
+            border-radius: 50%;
+            display: grid;
+            place-items: center;
+            box-shadow:
+                0 0 0 12px rgba(15, 23, 42, 0.45),
+                0 30px 80px rgba(15, 23, 42, 0.6);
+        }
+
+        .arena-character-core {
+            width: 48%;
+            aspect-ratio: 1 / 1;
+            border-radius: 50%;
+            background: rgba(15, 23, 42, 0.85);
+            box-shadow:
+                inset 0 0 0 2px rgba(241, 245, 249, 0.18),
+                inset 0 0 24px rgba(15, 23, 42, 0.8);
+        }
+
+        .arena-waves {
+            position: absolute;
+            inset: 10%;
+            border-radius: 50%;
+            border: 1px dashed rgba(148, 197, 255, 0.28);
+            animation: pulse 6s ease-in-out infinite;
+            mix-blend-mode: screen;
+        }
+
+        .arena-start {
+            margin-top: clamp(18px, 2.6vw, 24px);
+            padding: clamp(16px, 2.8vw, 20px) clamp(42px, 6vw, 60px);
+            font-size: clamp(18px, 2.6vw, 22px);
+            font-weight: 700;
+            border-radius: 999px;
+            box-shadow:
+                0 24px 60px rgba(34, 197, 94, 0.28),
+                0 0 0 1px rgba(74, 222, 128, 0.35);
+        }
+
+        .control-card {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .control-card input[type='text'],
+        .control-card input[type='number'] {
+            background: rgba(15, 23, 42, 0.65);
+            border-radius: 16px;
+            border: 1px solid rgba(59, 130, 246, 0.32);
+            padding: 14px 16px;
+            color: #f8fafc;
+            font-size: 15px;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .control-card input[type='text']:focus-visible,
+        .control-card input[type='number']:focus-visible {
+            outline: none;
+            border-color: rgba(147, 197, 253, 0.6);
+            box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.2);
+        }
+
+        .skin-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
+            gap: 14px;
+            margin-top: 12px;
+        }
+
+        .skin-token {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            border-radius: 50%;
+            border: none;
+            cursor: pointer;
+            display: grid;
+            place-items: center;
+            overflow: hidden;
+            box-shadow:
+                0 0 0 1px rgba(148, 163, 184, 0.16),
+                0 16px 30px rgba(15, 23, 42, 0.6);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+        }
+
+        .skin-token:hover,
+        .skin-token:focus-visible {
+            transform: translateY(-2px) scale(1.04);
+            filter: brightness(1.05);
+            box-shadow:
+                0 0 0 2px rgba(147, 197, 253, 0.45),
+                0 22px 40px rgba(59, 130, 246, 0.28);
+        }
+
+        .skin-token.selected {
+            box-shadow:
+                0 0 0 3px rgba(250, 250, 250, 0.45),
+                0 0 35px rgba(255, 255, 255, 0.35);
+        }
+
+        .skin-token-ring {
+            width: 58%;
+            height: 58%;
+            border-radius: 50%;
+            border: 2px solid rgba(15, 23, 42, 0.6);
+            background: rgba(15, 23, 42, 0.35);
+        }
+
+        .result-card {
+            gap: 16px;
         }
 
 


### PR DESCRIPTION
## Summary
- restructure the lobby view into a three-column layout with a profile header and central arena call-to-action
- add a glassmorphism balance widget plus utility controls for wallet, stats, and leaders tied together with neon styling
- refresh skin selection, bet controls, and arena visuals with responsive spacing and animated gradients

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8159ddcc833180bd1edcbbf65692