### PR TITLE
Redesign wallet button and simplify mobile controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,8 +11,6 @@ import { useWinningsLeaderboard, type LeaderboardRange } from './hooks/useWinnin
 import { usePlayerStats } from './hooks/usePlayerStats'
 import { ScorePanel } from './components/ScorePanel'
 import { GameLeaderboard } from './components/Leaderboard'
-import { Minimap } from './components/Minimap'
-import { TouchControls } from './components/TouchControls'
 import { CashoutControl } from './components/CashoutControl'
 import { NicknameScreen } from './components/NicknameScreen'
 import { AuthModal } from './components/AuthModal'
@@ -20,12 +18,7 @@ import { AdminDashboard } from './components/AdminDashboard'
 
 function GameView() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const minimapRef = useRef<HTMLCanvasElement>(null)
-  const joystickRef = useRef<HTMLDivElement>(null)
-  const joystickHandleRef = useRef<HTMLDivElement>(null)
-  const boostButtonRef = useRef<HTMLButtonElement>(null)
   const cashoutButtonRef = useRef<HTMLButtonElement>(null)
-  const touchControlsRef = useRef<HTMLDivElement>(null)
 
   const game = useGame()
   const auth = useAuth()
@@ -62,16 +55,9 @@ function GameView() {
   }, [winningsLeaderboard.data?.priceUsd])
   const accountStateSyncedRef = useRef(false)
 
-  useCanvas({ canvasRef, minimapRef, controller: game.controller })
+  useCanvas({ canvasRef, controller: game.controller })
   usePointerControls({ controller: game.controller, canvasRef })
-  useJoystick({
-    controller: game.controller,
-    joystickRef,
-    joystickHandleRef,
-    boostButtonRef,
-    cashoutButtonRef,
-    touchControlsRef
-  })
+  useJoystick({ controller: game.controller, cashoutButtonRef })
 
   const normalizeBetInput = useCallback((value: string, maxBalanceValue: number) => {
     if (value === '') return ''
@@ -295,14 +281,6 @@ function GameView() {
       {!game.nicknameScreenVisible ? (
         <GameLeaderboard entries={game.leaderboard} meName={game.controller.state.meName} />
       ) : null}
-      <Minimap ref={minimapRef} />
-      <TouchControls
-        enabled={game.touchControlsEnabled}
-        joystickRef={joystickRef}
-        joystickHandleRef={joystickHandleRef}
-        boostButtonRef={boostButtonRef}
-        ref={touchControlsRef}
-      />
       <CashoutControl state={game.cashout} buttonRef={cashoutButtonRef} />
       <NicknameScreen
         visible={game.nicknameScreenVisible}

--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { formatNumber } from '../utils/helpers'
+import { useTranslation } from '../hooks/useTranslation'
 import { SKINS, SKIN_LABELS, type LastResultState } from '../hooks/useGame'
 import type { PlayerStatsData } from '../hooks/usePlayerStats'
 import type { LeaderboardRange, WinningsLeaderboardEntry } from '../hooks/useWinningsLeaderboard'
@@ -131,6 +132,7 @@ export function NicknameScreen({
     return '—'
   }, [derivedUsd])
   const showWallet = Boolean(walletAddress)
+  const { t } = useTranslation()
 
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle')
   const copyResetTimer = useRef<number | null>(null)
@@ -273,24 +275,28 @@ export function NicknameScreen({
             <aside className="lobby-column lobby-column-left">
               <div className="balance-widget glass-card">
                 <div className="balance-widget-header">
-                  <div className="balance-widget-title">Баланс</div>
+                  <div className="balance-widget-title">{t('balanceTitle')}</div>
                   <button
                     type="button"
                     className="icon-button"
                     onClick={() => (isAuthenticated ? setWalletModalOpen(true) : onStart())}
-                    aria-label="Кошелек"
+                    aria-label={t('walletButtonAriaLabel')}
                     disabled={!isAuthenticated}
                   >
                     <span className="icon-wallet" aria-hidden="true" />
+                    <span className="icon-button__text">
+                      <span className="icon-button__label">{t('walletButtonTitle')}</span>
+                      <span className="icon-button__caption">{t('walletButtonCaption')}</span>
+                    </span>
                   </button>
                 </div>
                 <div className="balance-widget-value">{formatNumber(balance)}</div>
                 <div className="balance-widget-meta">
-                  <span>Текущая ставка</span>
+                  <span>{t('currentBetLabel')}</span>
                   <strong>{formatNumber(currentBet)}</strong>
                 </div>
                 <div className="balance-widget-meta">
-                  <span>Скин</span>
+                  <span>{t('skinLabel')}</span>
                   <strong>{skinName}</strong>
                 </div>
                 {showWallet ? (
@@ -301,7 +307,7 @@ export function NicknameScreen({
                 ) : null}
                 {!isAuthenticated ? (
                   <button type="button" className="auth-link" onClick={onStart}>
-                    Авторизоваться
+                    {t('authPrompt')}
                   </button>
                 ) : null}
               </div>

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -4,8 +4,8 @@ import type { GameController } from './useGame'
 
 interface UseCanvasOptions {
   canvasRef: React.RefObject<HTMLCanvasElement>
-  minimapRef: React.RefObject<HTMLCanvasElement>
   controller: GameController
+  minimapRef?: React.RefObject<HTMLCanvasElement>
 }
 
 const DPR_LIMIT = 2.5
@@ -111,7 +111,7 @@ function buildHexPattern(ctx: CanvasRenderingContext2D) {
 export function useCanvas({ canvasRef, minimapRef, controller }: UseCanvasOptions) {
   useEffect(() => {
     const canvas = canvasRef.current
-    const minimap = minimapRef.current
+    const minimap = minimapRef?.current ?? null
     if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return

--- a/frontend/src/hooks/useJoystick.ts
+++ b/frontend/src/hooks/useJoystick.ts
@@ -3,11 +3,11 @@ import type { GameController } from './useGame'
 
 interface UseJoystickOptions {
   controller: GameController
-  joystickRef: React.RefObject<HTMLDivElement>
-  joystickHandleRef: React.RefObject<HTMLDivElement>
-  boostButtonRef: React.RefObject<HTMLButtonElement>
-  cashoutButtonRef: React.RefObject<HTMLButtonElement>
-  touchControlsRef: React.RefObject<HTMLDivElement>
+  joystickRef?: React.RefObject<HTMLDivElement>
+  joystickHandleRef?: React.RefObject<HTMLDivElement>
+  boostButtonRef?: React.RefObject<HTMLButtonElement>
+  cashoutButtonRef?: React.RefObject<HTMLButtonElement>
+  touchControlsRef?: React.RefObject<HTMLDivElement>
 }
 
 function updateHandle(joystick: HTMLDivElement, handle: HTMLDivElement, clientX: number, clientY: number) {
@@ -40,36 +40,49 @@ export function useJoystick({
   touchControlsRef
 }: UseJoystickOptions) {
   useEffect(() => {
+    if (typeof window === 'undefined') return
     const pointerMedia = window.matchMedia('(pointer: coarse)')
-    const touchControls = touchControlsRef.current
+    let lastEnabled: boolean | null = null
 
-    const setEnabled = (enabled: boolean) => {
-      controller.setTouchControlsEnabled(enabled)
-      document.body.classList.toggle('is-touch', enabled)
+    const updateEnabled = (matches: boolean) => {
+      const hasTouchUI = Boolean(touchControlsRef?.current)
+      const shouldEnable = hasTouchUI && matches
+      if (lastEnabled === shouldEnable) return
+      lastEnabled = shouldEnable
+      controller.setTouchControlsEnabled(shouldEnable)
+      document.body.classList.toggle('is-touch', shouldEnable)
+      const touchControls = touchControlsRef?.current
       if (touchControls) {
-        touchControls.classList.toggle('active', enabled)
-        touchControls.setAttribute('aria-hidden', enabled ? 'false' : 'true')
+        touchControls.classList.toggle('active', shouldEnable)
+        touchControls.setAttribute('aria-hidden', shouldEnable ? 'false' : 'true')
       }
-      resetHandle(joystickHandleRef.current)
+      if (!shouldEnable) {
+        resetHandle(joystickHandleRef?.current ?? null)
+      }
       controller.resetBoostIntent()
       controller.refreshBoostState(true)
     }
 
-    const handler = (event: MediaQueryListEvent | MediaQueryList) => {
-      setEnabled(event.matches)
+    updateEnabled(pointerMedia.matches)
+
+    const handler = (event: MediaQueryListEvent) => {
+      updateEnabled(event.matches)
     }
 
-    handler(pointerMedia)
     pointerMedia.addEventListener('change', handler)
 
     return () => {
       pointerMedia.removeEventListener('change', handler)
+      if (lastEnabled) {
+        controller.setTouchControlsEnabled(false)
+        document.body.classList.remove('is-touch')
+      }
     }
   }, [controller, joystickHandleRef, touchControlsRef])
 
   useEffect(() => {
-    const joystick = joystickRef.current
-    const handle = joystickHandleRef.current
+    const joystick = joystickRef?.current
+    const handle = joystickHandleRef?.current
     if (!joystick || !handle) return
     let active = false
 
@@ -109,7 +122,7 @@ export function useJoystick({
   }, [controller, joystickRef, joystickHandleRef])
 
   useEffect(() => {
-    const boostButton = boostButtonRef.current
+    const boostButton = boostButtonRef?.current
     if (!boostButton) return
 
     const startBoost = (event: PointerEvent) => {
@@ -147,7 +160,7 @@ export function useJoystick({
   }, [controller, boostButtonRef])
 
   useEffect(() => {
-    const cashoutButton = cashoutButtonRef.current
+    const cashoutButton = cashoutButtonRef?.current
     if (!cashoutButton) return
 
     const startHold = (event: PointerEvent) => {

--- a/frontend/src/hooks/useTranslation.ts
+++ b/frontend/src/hooks/useTranslation.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const TRANSLATIONS = {
+  ru: {
+    balanceTitle: 'Баланс',
+    walletButtonTitle: 'Кошелек',
+    walletButtonCaption: 'Управление средствами',
+    walletButtonAriaLabel: 'Открыть кошелек',
+    currentBetLabel: 'Текущая ставка',
+    skinLabel: 'Скин',
+    authPrompt: 'Авторизоваться'
+  },
+  en: {
+    balanceTitle: 'Balance',
+    walletButtonTitle: 'Wallet',
+    walletButtonCaption: 'Manage funds',
+    walletButtonAriaLabel: 'Open wallet',
+    currentBetLabel: 'Current bet',
+    skinLabel: 'Skin',
+    authPrompt: 'Sign in'
+  }
+} as const
+
+type Locale = keyof typeof TRANSLATIONS
+
+type TranslationKey = keyof (typeof TRANSLATIONS)['ru']
+
+const DEFAULT_LOCALE: Locale = 'ru'
+
+function detectLocale(): Locale {
+  if (typeof navigator === 'undefined') {
+    return DEFAULT_LOCALE
+  }
+  const language = navigator.language?.toLowerCase() ?? ''
+  if (language.startsWith('en')) {
+    return 'en'
+  }
+  return DEFAULT_LOCALE
+}
+
+export function useTranslation() {
+  const [locale, setLocale] = useState<Locale>(() => detectLocale())
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handleLanguageChange = () => {
+      setLocale(detectLocale())
+    }
+    window.addEventListener('languagechange', handleLanguageChange)
+    return () => {
+      window.removeEventListener('languagechange', handleLanguageChange)
+    }
+  }, [])
+
+  const translate = useCallback(
+    (key: TranslationKey) => {
+      const dictionary = TRANSLATIONS[locale] ?? TRANSLATIONS[DEFAULT_LOCALE]
+      return dictionary[key] ?? TRANSLATIONS[DEFAULT_LOCALE][key]
+    },
+    [locale]
+  )
+
+  return { locale, t: translate }
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1204,34 +1204,80 @@
         .icon-button {
             display: inline-flex;
             align-items: center;
-            justify-content: center;
-            width: 40px;
-            height: 40px;
-            border-radius: 14px;
-            border: 1px solid rgba(148, 163, 184, 0.24);
-            background: rgba(15, 23, 42, 0.6);
+            gap: 12px;
+            padding: 0 18px;
+            min-height: 44px;
+            border-radius: 16px;
+            border: 1px solid rgba(148, 163, 184, 0.28);
+            background: linear-gradient(140deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.78));
             color: #e2e8f0;
             cursor: pointer;
-            transition: all 0.2s ease;
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.4);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+            text-align: left;
         }
 
         .icon-button:hover:not(:disabled),
         .icon-button:focus-visible:not(:disabled) {
-            border-color: rgba(96, 165, 250, 0.6);
-            box-shadow: 0 12px 28px rgba(59, 130, 246, 0.18);
+            transform: translateY(-1px);
+            border-color: rgba(96, 165, 250, 0.65);
+            box-shadow: 0 18px 32px rgba(59, 130, 246, 0.22);
         }
 
         .icon-button:disabled {
-            opacity: 0.5;
+            opacity: 0.8;
             cursor: default;
+            box-shadow: none;
+            background: rgba(15, 23, 42, 0.55);
+        }
+
+        .icon-button__text {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            line-height: 1;
+        }
+
+        .icon-button__label {
+            font-size: 14px;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+            background: linear-gradient(135deg, #38bdf8, #a855f7);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .icon-button__caption {
+            margin-top: 3px;
+            font-size: 11px;
+            font-weight: 500;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(226, 232, 240, 0.72);
+        }
+
+        .icon-button:disabled .icon-button__label {
+            background: none;
+            color: rgba(148, 163, 184, 0.9);
+        }
+
+        .icon-button:disabled .icon-button__caption {
+            color: rgba(148, 163, 184, 0.7);
         }
 
         .icon-wallet {
-            width: 18px;
-            height: 18px;
-            border-radius: 4px;
+            width: 20px;
+            height: 20px;
+            border-radius: 6px;
             background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(59, 130, 246, 0.85));
-            box-shadow: 0 0 12px rgba(59, 130, 246, 0.5);
+            box-shadow: 0 0 14px rgba(59, 130, 246, 0.45);
+        }
+
+        .icon-button:disabled .icon-wallet {
+            box-shadow: none;
+            filter: grayscale(0.15);
+            opacity: 0.7;
         }
 
         .auth-link {


### PR DESCRIPTION
## Summary
- replace the wallet icon button with a translated label + caption and add a lightweight translation hook
- restyle the balance widget button and remove the minimap/virtual joystick so touch devices follow finger input
- keep canvas logic resilient to a missing minimap and ensure joystick bindings handle optional refs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacf2ce9308331b2bce7d50893df80