### PR TITLE
Implement USD-based betting flow and touch boost improvements

### DIFF
--- a/frontend/src/components/DeathScreen.tsx
+++ b/frontend/src/components/DeathScreen.tsx
@@ -1,13 +1,17 @@
+import { BET_OPTIONS_USD, formatUsdCents } from '../utils/helpers'
 import type { DeathScreenState } from '../hooks/useGame'
 
 interface DeathScreenProps {
   state: DeathScreenState
-  onBetChange: (value: string) => void
-  onBetBlur: () => void
+  betOptions?: readonly number[]
+  onBetSelect: (value: number) => void
   onRetry: () => void
 }
 
-export function DeathScreen({ state, onBetChange, onBetBlur, onRetry }: DeathScreenProps) {
+export function DeathScreen({ state, betOptions, onBetSelect, onRetry }: DeathScreenProps) {
+  const options = betOptions && betOptions.length ? betOptions : BET_OPTIONS_USD
+  const selectedBet = options.includes(Number(state.betValue)) ? Number(state.betValue) : options[0]
+
   return (
     <div id="deathScreen" className={state.visible ? 'overlay' : 'overlay hidden'}>
       <div className="card">
@@ -23,15 +27,18 @@ export function DeathScreen({ state, onBetChange, onBetBlur, onRetry }: DeathScr
         {state.showBetControl ? (
           <div className="bet-control" id="deathBetControl">
             <label htmlFor="retryBetInput">Новая ставка</label>
-            <input
-              id="retryBetInput"
-              type="number"
-              min={1}
-              step={1}
-              value={state.betValue}
-              onChange={(event) => onBetChange(event.target.value)}
-              onBlur={onBetBlur}
-            />
+            <div className="bet-options" role="group" aria-labelledby="retryBetInput">
+              {options.map((option) => (
+                <button
+                  type="button"
+                  key={`death-${option}`}
+                  className={`bet-option${selectedBet === option ? ' selected' : ''}`}
+                  onClick={() => onBetSelect(option)}
+                >
+                  {formatUsdCents(option * 100)}
+                </button>
+              ))}
+            </div>
             <div className="bet-hint">
               Доступно: <span id="deathBetBalance">{state.betBalance}</span>
             </div>

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -1,6 +1,6 @@
 import type { LeaderboardEntry } from '../hooks/useGame'
 import type { LeaderboardRange, WinningsLeaderboardEntry } from '../hooks/useWinningsLeaderboard'
-import { formatNumber } from '../utils/helpers'
+import { formatNumber, formatUsdCents } from '../utils/helpers'
 
 const RANGE_LABELS: Record<LeaderboardRange, string> = {
   '24h': '24 часа',
@@ -37,8 +37,8 @@ export function GameLeaderboard({ entries, meName }: GameLeaderboardProps) {
               <span className="name">
                 {idx + 1}. {entry.name}
               </span>
-              {typeof entry.bet === 'number' ? (
-                <span className="bet">Ставка: {formatNumber(entry.bet)}</span>
+              {typeof entry.betUsdCents === 'number' ? (
+                <span className="bet">Ставка: {formatUsdCents(entry.betUsdCents)}</span>
               ) : null}
             </div>
             <div className="amounts">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2829,34 +2829,39 @@
             margin-bottom: 8px;
         }
 
-        .bet-control input[type="number"] {
-            width: 100%;
+        .bet-options {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .bet-option {
+            flex: 1 1 88px;
             padding: 12px 14px;
             border-radius: 16px;
             border: 1px solid rgba(59, 130, 246, 0.3);
             background: linear-gradient(145deg, rgba(8, 16, 31, 0.92), rgba(12, 24, 46, 0.78));
             color: #f1f5f9;
-            font-size: 16px;
+            font-size: 15px;
             font-weight: 600;
             outline: none;
-            appearance: textfield;
-            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
             box-shadow:
                 inset 0 0 0 1px rgba(15, 23, 42, 0.4),
                 0 12px 32px rgba(15, 23, 42, 0.45);
+            background-clip: padding-box;
         }
 
-        .bet-control input[type="number"]:focus {
-            border-color: rgba(56, 189, 248, 0.65);
+        .bet-option:hover {
+            border-color: rgba(56, 189, 248, 0.45);
+        }
+
+        .bet-option.selected {
+            border-color: rgba(56, 189, 248, 0.85);
             box-shadow:
                 0 0 0 3px rgba(56, 189, 248, 0.24),
                 0 16px 36px rgba(37, 99, 235, 0.24);
-        }
-
-        .bet-control input[type="number"]::-webkit-outer-spin-button,
-        .bet-control input[type="number"]::-webkit-inner-spin-button {
-            -webkit-appearance: none;
-            margin: 0;
+            transform: translateY(-1px);
         }
 
         .bet-control .bet-hint {
@@ -3063,7 +3068,7 @@
             margin-bottom: 16px;
         }
 
-        #deathScreen .bet-control input[type="number"] {
+        #deathScreen .bet-option {
             background: rgba(11, 18, 30, 0.92);
         }
 

--- a/frontend/src/utils/drawing.ts
+++ b/frontend/src/utils/drawing.ts
@@ -1,4 +1,4 @@
-import { formatNumber, shadeColor, withAlpha } from './helpers'
+import { formatNumber, formatUsdCents, shadeColor, withAlpha } from './helpers'
 
 type SnakePoint = { x: number; y: number }
 
@@ -17,6 +17,7 @@ type SnakeState = {
   targetDir?: number
   alive?: boolean
   speed?: number
+  betUsdCents?: number
 }
 
 type FoodState = {
@@ -284,8 +285,8 @@ export function drawSnakes({
       ctx.textAlign = 'center'
       ctx.textBaseline = 'bottom'
       const labelParts = [snake.name]
-      if (typeof snake.bet === 'number' && snake.bet > 0) {
-        labelParts.push(`ставка ${formatNumber(Math.floor(snake.bet))}`)
+      if (typeof snake.betUsdCents === 'number' && snake.betUsdCents > 0) {
+        labelParts.push(`ставка ${formatUsdCents(Math.floor(snake.betUsdCents))}`)
       }
       ctx.fillText(labelParts.join(' · '), head.x, head.y - headRadius - 10)
     }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -3,12 +3,24 @@ export function formatNumber(value: number | null | undefined): string {
   return safe.toLocaleString('ru-RU')
 }
 
-export function sanitizeBetValue(value: number | string | null | undefined, maxBalance: number): number {
-  const max = Math.max(0, Math.floor(maxBalance || 0))
-  if (max <= 0) return 0
-  const raw = Math.floor(Number(value) || 0)
-  if (raw < 1) return 1
-  return Math.min(raw, max)
+export const BET_OPTIONS_USD = [1, 5, 20] as const
+
+export function sanitizeBetValue(value: number | string | null | undefined): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return BET_OPTIONS_USD.includes(parsed as (typeof BET_OPTIONS_USD)[number]) ? parsed : 0
+}
+
+const usdFormatter = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2
+})
+
+export function formatUsdCents(value: number | null | undefined): string {
+  const cents = Math.max(0, Math.floor(Number(value) || 0))
+  return usdFormatter.format(cents / 100)
 }
 
 export function lerp(a: number, b: number, t: number): number {


### PR DESCRIPTION
## Summary
- enforce USD-denominated betting on the backend with SOL price caching, longer spawn length, faster boost, and USD-aware snapshots/leaderboard entries
- split defeated snakes' wagers into $0.20 golden foods that credit balance on pickup before payout is available
- refresh the lobby, death screen, and HUD to show USD bet options, add mobile double-tap boost, and display USD wagers in the UI

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68dad5a4bc9c8331bed1d7c402172aff