### PR TITLE
Fix canvas hook dependency array

### DIFF
--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -166,5 +166,5 @@ export function useCanvas({ canvasRef, controller }: UseCanvasOptions) {
       if (animationFrame) cancelAnimationFrame(animationFrame)
       window.removeEventListener('resize', handleResize)
     }
-  }, [canvasRef, minimapRef, controller])
+  }, [canvasRef, controller])
 }


### PR DESCRIPTION
## Summary
- remove the undefined minimapRef value from the canvas hook dependency array
- prevent runtime crashes caused by the invalid reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbc726c1dc8331873f62cfaea7e1c6