### PR TITLE
Rebrand lobby interface to SnakeFans

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>slither_client</title>
+    <title>SnakeFans — Skill-Based Betting</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400..900&display=swap" rel="stylesheet">

--- a/frontend/src/components/NicknameScreen.tsx
+++ b/frontend/src/components/NicknameScreen.tsx
@@ -322,13 +322,13 @@ export function NicknameScreen({
 
   const handleManageAffiliate = useCallback(() => {
     if (typeof window !== 'undefined') {
-      window.open('https://damnbruh.com/affiliate', '_blank', 'noreferrer')
+      window.open('https://snakefans.com/affiliate', '_blank', 'noreferrer')
     }
   }, [])
 
   const handleDiscordClick = useCallback(() => {
     if (typeof window !== 'undefined') {
-      window.open('https://discord.gg/damnbruh', '_blank', 'noreferrer')
+      window.open('https://discord.gg/snakefans', '_blank', 'noreferrer')
     }
   }, [])
 
@@ -364,7 +364,7 @@ export function NicknameScreen({
             </div>
             <div className="damn-topbar__details">
               <span className="damn-topbar__role">{isAuthenticated ? 'Signed in' : 'Guest'}</span>
-              <span className="damn-topbar__site">www.snakefans.com</span>
+              <span className="damn-topbar__site">snakefans.com</span>
             </div>
           </div>
         </div>
@@ -718,8 +718,8 @@ export function NicknameScreen({
           <button type="button" className="damn-secondary-button" onClick={handleDiscordClick}>
             Join Discord!
           </button>
-          <a className="damn-footer__link" href="https://damnbruh.com" target="_blank" rel="noreferrer">
-            damnbruh.com
+          <a className="damn-footer__link" href="https://snakefans.com" target="_blank" rel="noreferrer">
+            snakefans.com
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the lobby affiliate, Discord, and footer links to point at snakefans domains
- refresh the displayed site label and document title to match the SnakeFans branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd006145ac8331957b3ddcf8861615