### PR TITLE
Adjust lobby background styling

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3048,20 +3048,20 @@ body.is-touch #leaderboard {
     align-items: stretch;
     justify-content: center;
     padding: clamp(24px, 5vh, 72px) clamp(18px, 8vw, 84px);
-    background-color: #06070c;
-    background-image: radial-gradient(circle at 50% -10%, rgba(255, 204, 0, 0.18), transparent 60%),
-    linear-gradient(30deg, rgba(255, 204, 0, 0.08) 12%, transparent 12.5%, transparent 87%, rgba(255, 204, 0, 0.08) 87.5%, rgba(255, 204, 0, 0.08)),
-    linear-gradient(150deg, rgba(255, 204, 0, 0.08) 12%, transparent 12.5%, transparent 87%, rgba(255, 204, 0, 0.08) 87.5%, rgba(255, 204, 0, 0.08)),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0.62));
-    background-size: auto, 64px 110px, 64px 110px, 100% 100%;
-    background-position: 0 0, 0 0, 32px 55px, 0 0;
+    background-color: #03050a;
+    background-image: radial-gradient(circle at 15% 20%, rgba(90, 104, 136, 0.22), transparent 58%),
+    radial-gradient(circle at 82% 18%, rgba(66, 78, 110, 0.28), transparent 60%),
+    radial-gradient(circle at 72% 82%, rgba(48, 56, 80, 0.18), transparent 62%),
+    repeating-linear-gradient(-45deg, rgba(255, 255, 255, 0.05) 0, rgba(255, 255, 255, 0.05) 1px, transparent 1px, transparent 18px),
+    linear-gradient(140deg, #020308 0%, #03060d 45%, #05070f 100%);
+    background-blend-mode: screen, screen, screen, overlay, normal;
     overflow-y: auto;
 }
 
 .overlay--lobby::before {
-    opacity: 0.45;
-    background: radial-gradient(circle at 18% 20%, rgba(255, 255, 255, 0.08), transparent 55%),
-    radial-gradient(circle at 82% 78%, rgba(255, 204, 0, 0.16), transparent 60%);
+    opacity: 0.42;
+    background: radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.12), transparent 58%),
+    radial-gradient(circle at 78% 76%, rgba(120, 130, 160, 0.18), transparent 62%);
 }
 
 .overlay--lobby .damn-lobby {


### PR DESCRIPTION
## Summary
- restyle the lobby overlay background to mirror the game's ambience with darker monochrome gradients

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd0f6a2470833189ce1f0cbc1dfe53