### PR TITLE
Refine lobby cashout UI and respawn handling

### DIFF
--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -767,6 +767,15 @@ export class GameController {
     if (snapshot.you && typeof snapshot.you.length === 'number') {
       this.updateScoreHUD(Math.floor(snapshot.you.length))
     }
+
+    if (snapshot.you && typeof snapshot.you.alive === 'boolean') {
+      const nextAlive = Boolean(snapshot.you.alive)
+      if (nextAlive !== this.state.alive) {
+        this.state.alive = nextAlive
+        this.refreshCashoutState()
+      }
+    }
+
     this.refreshBoostState()
     this.state.lastSnapshotAt = performance.now()
     this.notify()

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2429,6 +2429,10 @@ canvas {
     transform: none;
 }
 
+.damn-card--wallet .wallet-withdraw {
+    margin-top: 16px;
+}
+
 .wallet-withdraw-status {
     font-size: 12px;
     letter-spacing: 0.06em;
@@ -2440,6 +2444,13 @@ canvas {
 
 .wallet-withdraw-status.success {
     color: #bbf7d0;
+}
+
+.wallet-withdraw-status--summary {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: rgba(30, 41, 59, 0.65);
 }
 
 .wallet-modal-section {


### PR DESCRIPTION
## Summary
- ensure the game controller marks the player as alive again when snapshots show an active snake to restore the camera after respawns
- derive an effective betting balance that keeps stake selectors and respawn flows in sync with account updates
- move the cash-out form into the lobby wallet card with inline status messaging and remove the modal-based withdrawal UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd27be215483318b3e27dd8be494eb