### PR TITLE
feat: add lobby skin modal with animated preview

### DIFF
--- a/frontend/src/components/FriendsModal.tsx
+++ b/frontend/src/components/FriendsModal.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Modal } from './Modal'
-import { useFriends, type FriendRequestEntry, type FriendSearchResult, type FriendSummary } from '../hooks/useFriends'
+import {
+  type FriendRequestEntry,
+  type FriendSearchResult,
+  type FriendSummary,
+  type UseFriendsResult
+} from '../hooks/useFriends'
 
 type TabKey = 'friends' | 'outgoing' | 'incoming'
 
@@ -23,13 +28,12 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 interface FriendsModalProps {
   open: boolean
-  token: string | null
+  controller: UseFriendsResult
   onClose: () => void
 }
 
-export function FriendsModal({ open, token, onClose }: FriendsModalProps) {
-  const { friends, outgoing, incoming, loading, error, refresh, search, sendRequest, acceptRequest } =
-    useFriends(token)
+export function FriendsModal({ open, controller, onClose }: FriendsModalProps) {
+  const { friends, outgoing, incoming, loading, error, refresh, search, sendRequest, acceptRequest } = controller
   const [activeTab, setActiveTab] = useState<TabKey>('friends')
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<FriendSearchResult[]>([])

--- a/frontend/src/components/SnakePreview.tsx
+++ b/frontend/src/components/SnakePreview.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+
+interface SnakePreviewProps {
+  colors: string[]
+  length?: number
+  width?: number
+  height?: number
+}
+
+const DEFAULT_COLOR = '#38bdf8'
+const DEFAULT_LENGTH = 100
+const DEFAULT_WIDTH = 360
+const DEFAULT_HEIGHT = 160
+
+export function SnakePreview({
+  colors,
+  length = DEFAULT_LENGTH,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT
+}: SnakePreviewProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const context = canvas.getContext('2d')
+    if (!context) return
+
+    const logicalWidth = width
+    const logicalHeight = height
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1
+      canvas.width = logicalWidth * dpr
+      canvas.height = logicalHeight * dpr
+      canvas.style.width = `${logicalWidth}px`
+      canvas.style.height = `${logicalHeight}px`
+    }
+
+    resize()
+
+    let animationId: number
+
+    const draw = (time: number) => {
+      const dpr = window.devicePixelRatio || 1
+      context.save()
+      context.setTransform(dpr, 0, 0, dpr, 0, 0)
+      context.clearRect(0, 0, logicalWidth, logicalHeight)
+
+      const headX = logicalWidth * 0.75
+      const centerY = logicalHeight / 2
+      const amplitude = logicalHeight * 0.18
+      const spacing = Math.max(2.2, (logicalWidth * 0.7) / Math.max(length, 1))
+      const segmentCount = Math.max(8, Math.min(length, 220))
+      const path: { x: number; y: number }[] = []
+
+      for (let i = 0; i < segmentCount; i += 1) {
+        const progress = i / segmentCount
+        const angle = time * 0.004 + progress * 9.2
+        const falloff = 1 - progress * 0.65
+        const offsetX = headX - i * spacing
+        const offsetY = centerY + Math.sin(angle) * amplitude * falloff
+        path.push({ x: offsetX, y: offsetY })
+      }
+
+      if (path.length > 1) {
+        const gradient = context.createLinearGradient(
+          path[path.length - 1].x,
+          path[path.length - 1].y,
+          path[0].x,
+          path[0].y
+        )
+        const palette = colors.length > 0 ? colors : [DEFAULT_COLOR]
+        const step = palette.length > 1 ? 1 / (palette.length - 1) : 1
+        palette.forEach((color, index) => {
+          gradient.addColorStop(index * step, color)
+        })
+
+        context.lineCap = 'round'
+        context.lineJoin = 'round'
+        context.lineWidth = 18
+        context.strokeStyle = gradient
+        context.shadowColor = palette[0] ?? DEFAULT_COLOR
+        context.shadowBlur = 22
+
+        context.beginPath()
+        context.moveTo(path[0].x, path[0].y)
+        for (let i = 1; i < path.length; i += 1) {
+          const point = path[i]
+          context.lineTo(point.x, point.y)
+        }
+        context.stroke()
+
+        context.shadowBlur = 0
+        context.lineWidth = 12
+        context.strokeStyle = 'rgba(255, 255, 255, 0.18)'
+        context.beginPath()
+        context.moveTo(path[0].x, path[0].y)
+        for (let i = 1; i < path.length; i += 1) {
+          context.lineTo(path[i].x, path[i].y)
+        }
+        context.stroke()
+      }
+
+      context.restore()
+      animationId = window.requestAnimationFrame(draw)
+    }
+
+    animationId = window.requestAnimationFrame(draw)
+
+    const handleResize = () => {
+      resize()
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.cancelAnimationFrame(animationId)
+    }
+  }, [colors, height, length, width])
+
+  return (
+    <div className="snake-preview" aria-hidden="true">
+      <canvas ref={canvasRef} className="snake-preview__canvas" />
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFriends.ts
+++ b/frontend/src/hooks/useFriends.ts
@@ -193,3 +193,5 @@ export function useFriends(token: string | null) {
     hasFriends
   }
 }
+
+export type UseFriendsResult = ReturnType<typeof useFriends>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3756,32 +3756,33 @@ body.is-touch #leaderboard {
 
 .damn-customize__preview {
     position: relative;
-    height: 120px;
-    margin-bottom: 24px;
+    height: 160px;
+    margin-bottom: 20px;
     border-radius: 22px;
-    background: linear-gradient(160deg, rgba(255, 204, 0, 0.12), rgba(255, 255, 255, 0.02));
+    background: linear-gradient(160deg, rgba(255, 204, 0, 0.12), rgba(255, 255, 255, 0.05));
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px;
 }
 
 .damn-customize__preview::before {
     content: '';
     position: absolute;
-    width: 220px;
-    height: 58px;
+    inset: 18% 8%;
     border-radius: 999px;
     background: linear-gradient(90deg, var(--accent-primary, #38bdf8), var(--accent-secondary, #8b5cf6));
-    top: 50%;
-    left: 18%;
-    transform: translate(-18%, -50%);
-    box-shadow: 0 18px 35px rgba(0, 0, 0, 0.4),
-    0 0 32px rgba(255, 255, 255, 0.16);
+    opacity: 0.45;
+    filter: blur(32px);
 }
 
 .damn-customize__highlight {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    margin-bottom: 18px;
+    margin-top: 20px;
+    margin-bottom: 4px;
 }
 
 .damn-customize__label {
@@ -3798,6 +3799,36 @@ body.is-touch #leaderboard {
 .damn-customize__amount {
     font-size: 14px;
     color: rgba(255, 255, 255, 0.7);
+}
+
+.snake-preview {
+    position: relative;
+    width: 100%;
+    max-width: 360px;
+    aspect-ratio: 18 / 8;
+}
+
+.snake-preview__canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.45));
+}
+
+.skin-change-button {
+    margin-top: 4px;
+}
+
+.skin-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.skin-modal__hint {
+    font-size: 14px;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.72);
 }
 
 .damn-skin-grid {
@@ -3853,13 +3884,108 @@ body.is-touch #leaderboard {
 }
 
 .damn-card--friends {
-    min-height: 180px;
+    min-height: 220px;
     display: flex;
     flex-direction: column;
+    gap: 16px;
 }
 
-.damn-card--friends .friends-add-button {
+.friends-preview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.friends-preview-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: rgba(24, 26, 35, 0.7);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+}
+
+.friends-preview-avatar {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    background: linear-gradient(135deg, #6366f1, #22d3ee);
+    color: #0b0d16;
+    text-transform: uppercase;
+}
+
+.friends-preview-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.friends-preview-name {
+    font-weight: 600;
+    color: #fff;
+}
+
+.friends-preview-meta {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.65);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.friends-preview-since {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.friends-preview-empty {
+    padding: 16px;
+    border-radius: 18px;
+    border: 1px dashed rgba(255, 255, 255, 0.18);
+    background: rgba(24, 26, 35, 0.5);
+    text-align: center;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.friends-actions-grid {
     margin-top: auto;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.friends-card-button {
+    padding: 12px 16px;
+    border-radius: 16px;
+    border: none;
+    font-size: 14px;
+    font-weight: 700;
+    color: #0b0d16;
+    background: linear-gradient(135deg, #6366f1, #22d3ee);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.friends-card-button:hover,
+.friends-card-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+}
+
+.friends-card-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 3px;
 }
 
 .friends-modal {


### PR DESCRIPTION
## Summary
- add an animated snake preview in the lobby and move skin selection into a dedicated modal
- surface the first three friends in the lobby with refreshed styling and shared state for the friends modal
- update shared styles to support the new preview canvas and action buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd2c3cff3483319bda5c8eab644126